### PR TITLE
Add initial codeowners for WTS

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,2 @@
+# Code owners below will be automatically assigned as automatic PR reviewers:
+@trevorNgo @Kai-Bailey @amrrsharaff @dandua98 @ngkelly3 @SahilTara


### PR DESCRIPTION
Adds WTS members as code reviewers.
Madrid to be added soon after once this works.