### PR TITLE
Updating CODEOWNERS to enforce PR policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Code owners below will be automatically assigned as automatic PR reviewers:
-* @trevorNgo @Kai-Bailey @amrrsharaff @dandua98 @ngkelly3 @SahilTara @KirillShchetinin @mohannad-abwah @tejbirsingh @markAtMicrosoft @sibille @mvegaca @dgomezc
+# At least one of the code owners below will be required on each PR:
+* @KirillShchetinin @mohannad-abwah @tejbirsingh @markAtMicrosoft @sibille @mvegaca @dgomezc @smmatte


### PR DESCRIPTION
At least of one of: Mark, Stephane, coaches, madrid must approve PRs to get them checked in.