### PR TITLE
retain context when hidden

### DIFF
--- a/src/extension/src/reactPanel.ts
+++ b/src/extension/src/reactPanel.ts
@@ -16,7 +16,7 @@ export class ReactPanel {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionPath: string;
   private _disposables: vscode.Disposable[] = [];
-  private static _controllerFunctionDelegate = function(message: any) {
+  private static _controllerFunctionDelegate = function (message: any) {
     if (message.command === "alert") {
       vscode.window.showErrorMessage(message.text);
     }
@@ -68,6 +68,9 @@ export class ReactPanel {
       {
         // Enable javascript in the webview
         enableScripts: true,
+
+        // Keep the wizard in its current state
+        retainContextWhenHidden: true,
 
         // And restric the webview to only loading content from our extension's `media` directory.
         localResourceRoots: [
@@ -141,8 +144,8 @@ export class ReactPanel {
 				<link rel="stylesheet" type="text/css" href="${styleUri}">
 				<meta img-src vscode-resource: https: ;style-src vscode-resource: 'unsafe-inline' http: https: data:;">
 				<base href="${vscode.Uri.file(path.join(this._extensionPath, "react")).with({
-          scheme: "vscode-resource"
-        })}/">
+      scheme: "vscode-resource"
+    })}/">
 			</head>
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
- This keeps the wizard running in the background when the user switches tabs on Visual Studio Code.

- Created #136 to keep this in the backlog.

Addresses: 

[AB#24813](https://microsoftgarage.visualstudio.com/web/wi.aspx?pcguid=a5a3dbc0-4c76-4b02-a530-42fde31e44df&id=24813)