### PR TITLE
vsix azure templates bug fix

### DIFF
--- a/src/extension/.vscodeignore
+++ b/src/extension/.vscodeignore
@@ -9,3 +9,6 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 !src/api/**
+!src/azure-cosmosDB/arm-templates
+!src/azure-functions/arm-templates
+!src/azure-functions/templates

--- a/src/extension/src/azure-arm/resourceManager.ts
+++ b/src/extension/src/azure-arm/resourceManager.ts
@@ -17,7 +17,7 @@ export class ResourceManager {
       userSubscriptionItem.subscription === undefined ||
       userSubscriptionItem.subscriptionId === undefined
     ) {
-      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_UNDEFINED);
+      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_DEFINED);
     }
     return new ResourceManagementClient(
       userCredentials,

--- a/src/extension/src/azure-cosmosDB/cosmosDbModule.ts
+++ b/src/extension/src/azure-cosmosDB/cosmosDbModule.ts
@@ -221,7 +221,7 @@ export class CosmosDBDeploy {
     try {
       if (this.SubscriptionItemCosmosClient === undefined) {
         throw new AuthorizationError(
-          CONSTANTS.ERRORS.COSMOS_CLIENT_NOT_UNDEFINED
+          CONSTANTS.ERRORS.COSMOS_CLIENT_NOT_DEFINED
         );
       }
 
@@ -294,7 +294,7 @@ export class CosmosDBDeploy {
       userSubscriptionItem.subscription === undefined ||
       userSubscriptionItem.subscriptionId === undefined
     ) {
-      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_UNDEFINED);
+      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_DEFINED);
     }
     return new CosmosDBManagementClient(
       userCredentials,
@@ -324,9 +324,7 @@ export class CosmosDBDeploy {
   ): Promise<string | undefined> {
     // let client: CosmosDBManagementClient = this.createCosmosClient(userSubscriptionItem);
     if (this.SubscriptionItemCosmosClient === undefined) {
-      throw new AuthorizationError(
-        CONSTANTS.ERRORS.COSMOS_CLIENT_NOT_UNDEFINED
-      );
+      throw new AuthorizationError(CONSTANTS.ERRORS.COSMOS_CLIENT_NOT_DEFINED);
     }
     name = name ? name.trim() : "";
 

--- a/src/extension/src/azure-functions/functionProvider.ts
+++ b/src/extension/src/azure-functions/functionProvider.ts
@@ -264,7 +264,7 @@ export class FunctionProvider {
       userSubscriptionItem.subscription === undefined ||
       userSubscriptionItem.subscriptionId === undefined
     ) {
-      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_UNDEFINED);
+      throw new SubscriptionError(CONSTANTS.ERRORS.SUBSCRIPTION_NOT_DEFINED);
     }
 
     return new WebSiteManagementClient(
@@ -296,9 +296,7 @@ export class FunctionProvider {
     ValidationHelper.validateFunctionAppName(appName);
 
     if (this.webClient === undefined) {
-      throw new AuthorizationError(
-        CONSTANTS.ERRORS.WEBSITE_CLIENT_NOT_UNDEFINED
-      );
+      throw new AuthorizationError(CONSTANTS.ERRORS.WEBSITE_CLIENT_NOT_DEFINED);
     }
 
     return await this.webClient

--- a/src/extension/src/constants.ts
+++ b/src/extension/src/constants.ts
@@ -3,35 +3,34 @@ export const CONSTANTS = {
     INVALID_COMMAND: "Invalid command used",
     RESOURCE_GROUP_NOT_FOUND: "No resource group found with this name",
     SUBSCRIPTION_NOT_FOUND: "No subscription found with this name.",
-    FUNCTION_APP_NAME_NOT_AVAILABLE: function(functionName: string) {
+    FUNCTION_APP_NAME_NOT_AVAILABLE: (functionName: string) => {
       return `Function app name ${functionName} is not available`;
     },
     LOGIN_TIMEOUT: "Timeout. User is not logged in",
     SESSION_NOT_AVAILABLE:
       "There is no session available. Make sure the user is logged in.",
-    SUBSCRIPTION_NOT_UNDEFINED:
-      "Subscription Item cannot have undefined values.",
-    WEBSITE_CLIENT_NOT_UNDEFINED:
+    SUBSCRIPTION_NOT_DEFINED: "Subscription Item cannot have undefined values.",
+    WEBSITE_CLIENT_NOT_DEFINED:
       "Website management client cannot be undefined.",
-    COSMOS_CLIENT_NOT_UNDEFINED: "Cosmos client cannot be undefined",
+    COSMOS_CLIENT_NOT_DEFINED: "Cosmos client cannot be undefined",
     CONNECTION_STRING_FAILED:
       "CosmosDBDeploy: GetConnectionString Failed to create Client with SubscriptionItem - ",
     RUNTIME_NOT_IMPLEMENTED: "Runtime not implemented yet",
     FUNCTIONS_NO_DUPLICATES: "No duplicates allowed for function names",
-    FUNCTIONS_INVALID_NAME: function(name: string) {
+    FUNCTIONS_INVALID_NAME: (name: string) => {
       return `Invalid function name ${name}. Name can only include alphanumeric characters and dashes, and must start/end with alphanumeric characters`;
     },
-    COSMOS_ACCOUNT_NOT_AVAILABLE: function(name: string) {
+    COSMOS_ACCOUNT_NOT_AVAILABLE: (name: string) => {
       return `Account name "${name}" is not available.`;
     },
     COSMOS_VALID_CHARACTERS:
       "The name can only contain lowercase letters, numbers, and the '-' character.",
-    NAME_MIN_MAX: function(min: Number, max: Number) {
+    NAME_MIN_MAX: (min: Number, max: Number) => {
       return `The name must be between ${min} and ${max} characters.`;
     }
   },
   INFO: {
-    COSMOS_ACCOUNT_DEPLOYED: function(accountName: string) {
+    COSMOS_ACCOUNT_DEPLOYED: (accountName: string) => {
       return `${accountName} has been deployed!`;
     }
   },


### PR DESCRIPTION
This PR fixes missing templates from vsix bug and closes [AB#25059](https://microsoftgarage.visualstudio.com/web/wi.aspx?pcguid=a5a3dbc0-4c76-4b02-a530-42fde31e44df&id=25059). It also fixes a few warnings by the new TSlint config introduced recently (only in constants file) and cleans up a few constant names