### PR TITLE
Converted NavBar to bootstrap CSS

### DIFF
--- a/mocks/materialui-multi-page/src/components/NavBar/index.js
+++ b/mocks/materialui-multi-page/src/components/NavBar/index.js
@@ -1,38 +1,25 @@
 import React from "react";
-import AppBar from "@material-ui/core/AppBar";
-import Typography from "@material-ui/core/Typography";
-import Button from "@material-ui/core/Button";
-import Toolbar from "@material-ui/core/Toolbar";
-import CssBaseline from "@material-ui/core/CssBaseline";
-import { withStyles } from "@material-ui/core";
 
-const styles = theme => ({
-  appBar: {
-    zIndex: theme.zIndex.drawer + 1
-  },
-  toolbarTitle: {
-    flex: 1
-  }
-});
-
-function index(props) {
-  const { classes } = props;
+export default function NavBar() {
   return (
-    <React.Fragment>
-      <CssBaseline />
-      <AppBar position="sticky" color="default" className={classes.appBar}>
-        <Toolbar>
-          <Typography variant="h6" className={classes.toolbarTitle}>
-            Company name
-          </Typography>
-          <Button href="/masterdetail">Master Detail</Button>
-          <Button href="/list">List</Button>
-          <Button href="/grid">Grid</Button>
-          <Button href="/blank">Blank</Button>
-        </Toolbar>
-      </AppBar>
-    </React.Fragment>
+    <nav className="navbar navbar-expand-sm navbar-light border-bottom justify-content-between">
+      <a className="navbar-brand" href="/">
+        Project Name
+      </a>
+      <div className="navbar-nav">
+        <a className="nav-item nav-link active" href="/masterdetail">
+          Master Detail
+        </a>
+        <a className="nav-item nav-link active" href="/grid">
+          Content Grid
+        </a>
+        <a className="nav-item nav-link active" href="/list">
+          List
+        </a>
+        <a className="nav-item nav-link active" href="/blank">
+          Blank
+        </a>
+      </div>
+    </nav>
   );
 }
-
-export default withStyles(styles)(index);


### PR DESCRIPTION
Converted Navigation bar to bootstrap css.

Before:
![image](https://user-images.githubusercontent.com/24615518/54946542-83ff2000-4ef5-11e9-9992-24051584c703.png)

After:
![image](https://user-images.githubusercontent.com/24615518/54946244-e6a3ec00-4ef4-11e9-81e8-026c45deed8f.png)

Addresses:
[AB#24909](https://microsoftgarage.visualstudio.com/web/wi.aspx?pcguid=a5a3dbc0-4c76-4b02-a530-42fde31e44df&id=24909)