### PR TITLE
Limit page name length

### DIFF
--- a/src/client/src/containers/SortablePageList/index.tsx
+++ b/src/client/src/containers/SortablePageList/index.tsx
@@ -13,6 +13,8 @@ import { validateName } from "../../utils/validateName";
 
 import styles from "./styles.module.css";
 
+const MAX_PAGE_NAME_LENGTH = 50;
+
 interface ISortablePageListProps {
   pages: any[];
 }
@@ -40,9 +42,11 @@ const SortablePageList = (props: Props) => {
         pages[idx].error = PAGE_NAME_ERROR_MESSAGES.DUPLICATE_NAME;
         break;
       }
-    };
-    setPages(pages);
-    props.selectPages(pages);
+    }
+    if (pages[idx].title.length < MAX_PAGE_NAME_LENGTH) {
+      setPages(pages);
+      props.selectPages(pages);
+    }
   };
   const onSortEnd = ({
     oldIndex,


### PR DESCRIPTION
**CHANGES**:

- Set a limit for page names: 50

Addresses:
[AB#24950](https://microsoftgarage.visualstudio.com/web/wi.aspx?pcguid=a5a3dbc0-4c76-4b02-a530-42fde31e44df&id=24950)