### PR TITLE
Fixed typo in env vars

### DIFF
--- a/src/extension/src/constants.ts
+++ b/src/extension/src/constants.ts
@@ -80,7 +80,7 @@ export const CONSTANTS = {
     password: string,
     origin: string
   ) {
-    return `COSMOSDB_CONNSTR=${origin}/${username}\nCOSMODDB_USER=${username}\nCOSMOSDB_PASSWORD=${password}\n`;
+    return `COSMOSDB_CONNSTR=${origin}/${username}\nCOSMOSDB_USER=${username}\nCOSMOSDB_PASSWORD=${password}\n`;
   },
   MAX_PROJECT_NAME_LENGTH: 50,
   PORT: "5000"


### PR DESCRIPTION
- Fixes COSMOS env variable bug 

Addresses:

[AB#25967](https://microsoftgarage.visualstudio.com/web/wi.aspx?pcguid=a5a3dbc0-4c76-4b02-a530-42fde31e44df&id=25967)