### PR TITLE
Resolved bug with disappearing footer in the details page

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -156,8 +156,10 @@ class App extends React.Component<Props> {
           <LeftSidebar />
           <div
             className={classnames({
-              [appStyles.centerView]: pathname === ROUTES.WELCOME,
-              [appStyles.centerViewCropped]: pathname !== ROUTES.WELCOME
+              [appStyles.centerView]:
+                pathname === ROUTES.WELCOME || pathname == ROUTES.PAGE_DETAILS,
+              [appStyles.centerViewCropped]:
+                pathname !== ROUTES.WELCOME && pathname !== ROUTES.PAGE_DETAILS
             })}
           >
             <Route path={ROUTES.PAGE_DETAILS} component={PageDetails} />

--- a/src/client/src/containers/PageDetails/styles.module.css
+++ b/src/client/src/containers/PageDetails/styles.module.css
@@ -10,4 +10,5 @@
 
 .detailsContainer {
   display: flex;
+  margin-top: 51px; /*Height of the Title Bar */
 }


### PR DESCRIPTION
Removes the gap at the bottom of the detail page.

![image](https://user-images.githubusercontent.com/24615518/55520042-4c981e00-562f-11e9-84a3-7fec49671792.png)

Addresses:
#294 