### PR TITLE
Env file replacement pop up fix for Sql api

### DIFF
--- a/src/extension/src/azure/azure-cosmosDB/cosmosDbModule.ts
+++ b/src/extension/src/azure/azure-cosmosDB/cosmosDbModule.ts
@@ -399,12 +399,29 @@ export class CosmosDBDeploy {
      * Throws an error if the user deleted the project directory
      * @filePath: path of .env file
      */
-    const cosmosConnectionString = Url(connectionString);
-    const cosmosEnvironmentVariables = CONSTANTS.CONNECTION_STRING(
-      cosmosConnectionString.username,
-      cosmosConnectionString.password,
-      cosmosConnectionString.origin
-    );
+    let cosmosEnvironmentVariables = "";
+    if (
+      connectionString
+        .toLowerCase()
+        .startsWith(CONSTANTS.SQL_CONNECTION_STRING_PREFIX)
+    ) {
+      const [origin, primaryKey] = connectionString
+        .split(";")
+        .map(str => str.substr(str.indexOf("=") + 1));
+
+      cosmosEnvironmentVariables = CONSTANTS.CONNECTION_STRING_SQL(
+        origin,
+        primaryKey
+      );
+    } else {
+      const cosmosConnectionString = Url(connectionString);
+      cosmosEnvironmentVariables = CONSTANTS.CONNECTION_STRING_MONGO(
+        cosmosConnectionString.username,
+        cosmosConnectionString.password,
+        cosmosConnectionString.origin
+      );
+    }
+
     const path = filePath + "/" + ".env";
     try {
       if (fs.existsSync(filePath)) {

--- a/src/extension/src/azure/azureServices.ts
+++ b/src/extension/src/azure/azureServices.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import {
   AzureAuth,
   SubscriptionItem,
@@ -35,7 +35,6 @@ export abstract class AzureServices {
   }
 
   public static async getUserInfo() {
-
     this.subscriptionItemList = await AzureAuth.getSubscriptions();
 
     const subscriptionListToDisplay = this.subscriptionItemList.map(
@@ -134,7 +133,7 @@ export abstract class AzureServices {
         throw error;
       });
   }
-  
+
   public static async validateFunctionAppName(
     functionAppName: string,
     subscriptionLabel: string
@@ -254,7 +253,7 @@ export abstract class AzureServices {
       userCosmosDBSelection,
       genPath
     );
-  }  
+  }
   public static async promptUserForCosmosReplacement(
     pathToEnv: string,
     dbObject: DatabaseObject
@@ -275,7 +274,10 @@ export abstract class AzureServices {
             CONSTANTS.INFO.FILE_REPLACED_MESSAGE + pathToEnv
           );
         }
-        return {userReplacedEnv: selection === DialogResponses.yes, startTime: start};
+        return {
+          userReplacedEnv: selection === DialogResponses.yes,
+          startTime: start
+        };
       });
   }
 }

--- a/src/extension/src/constants.ts
+++ b/src/extension/src/constants.ts
@@ -162,13 +162,17 @@ export const CONSTANTS = {
     Project_Title: "Project Acorn"
   },
   GENERATE_ENDPOINT: "/api/generate",
-  CONNECTION_STRING: function(
+  CONNECTION_STRING_MONGO: function(
     username: string,
     password: string,
     origin: string
   ) {
     return `COSMOSDB_CONNSTR=${origin}/${username}\nCOSMOSDB_USER=${username}\nCOSMOSDB_PASSWORD=${password}\n`;
   },
+  CONNECTION_STRING_SQL: function(origin: string, primaryKey: string) {
+    return `COSMOSDB_URI=${origin}\nCOSMOSDB_PRIMARY_KEY=${primaryKey}\n`;
+  },
+  SQL_CONNECTION_STRING_PREFIX: "accountendpoint=",
   MAX_PROJECT_NAME_LENGTH: 50,
   PORT: "5000",
   VSCODE_COMMAND: {


### PR DESCRIPTION
Summary of changes:
- The connection string is different for mongo & sql, so now there is a check done on the connection string, and the string is handled accordingly.

Related issues:
closes #323 