### PR TITLE
provide null check if an error doesn't exists

### DIFF
--- a/src/client/src/components/SummaryTile/index.tsx
+++ b/src/client/src/components/SummaryTile/index.tsx
@@ -116,6 +116,7 @@ const SummaryTile = ({
                 ? subTitle
                 : serviceTitle && (
                     <React.Fragment>
+                      <div>{intl.formatMessage(serviceTitle)}</div>
                       <div>&nbsp;|&nbsp;</div>
                     </React.Fragment>
                   )}


### PR DESCRIPTION
Fixes bug where app crashes due to internationalizing error message