### PR TITLE
fixed createVsix deletion bug

### DIFF
--- a/src/client/src/translations/whitelist_en.json
+++ b/src/client/src/translations/whitelist_en.json
@@ -5,6 +5,7 @@
   "details.licenses",
   "details.version",
   "details.none",
+  "leftSidebar.giveFeedback",
   "leftSidebar.welcome",
   "leftSidebar.projectType",
   "leftSidebar.frameworks",

--- a/src/extension/gulpfile.js
+++ b/src/extension/gulpfile.js
@@ -27,11 +27,14 @@ const outDest = "out";
 const languages = [{ folderName: "en", id: "en" }];
 
 gulp.task("clean", function() {
-  return del([
-    "out/**",
-    "package.nls.*.json",
-    "../../dist/wts-0.0.0-UNTRACKEDVERSION.vsix"
-  ]);
+  return del(
+    [
+      "out/**",
+      "package.nls.*.json",
+      "../../dist/wts-0.0.0-UNTRACKEDVERSION.vsix"
+    ],
+    { force: true }
+  );
 });
 
 gulp.task("internal-compile", function() {


### PR DESCRIPTION
This PR fixes the `createVsix` failing if a *vsix* already exists in *dist/* bug created due to gulp using safe deletion for files not in the same directory as `gulpfile`

_**Testing Notes:**_

- Run the createVsix script (ensure *src/extension/dist* is empty initially).
- Run the script again. The script won't fail now.

Closes #387 