### PR TITLE
Specify vscode version in instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Web Template Studio runs as a VSCode extension and hence you'll need to have _VScode_ installed.
+Web Template Studio runs as a VSCode extension and hence you'll need to have _VScode_ version 1.33 or above installed.
 Also, you'll need _Node_ and _npm_/_yarn_ to run the generated templates.
 
 ## Installing the latest Microsoft Web Template Studio Release


### PR DESCRIPTION
The extension does not run on VSCode version 1.30. We are still exploring other versions. But for now we know that it works for version 1.33 and above. 

Related issues:
#409 