### PR TITLE
stop api module if sync failed

### DIFF
--- a/src/extension/src/controller.ts
+++ b/src/extension/src/controller.ts
@@ -98,6 +98,7 @@ export class Controller {
       vscode.window.showErrorMessage(
         CONSTANTS.ERRORS.TOO_MANY_FAILED_SYNC_REQUESTS
       );
+      ApiModule.StopApi();
       return process;
     }
 


### PR DESCRIPTION
If templates fail to sync before webview loads, a popup saying "Cannot Sync Template Repository" will show but WebTS fails to load.

Checking all processes listening on Port 5000 shows that the Core was initialized and running as a background process.

This fix will stop the engine if template sync fails.

Closes #434 