### PR TITLE
add chmod to core engine before attempting engine sync

### DIFF
--- a/src/client/src/translations/whitelist_en.json
+++ b/src/client/src/translations/whitelist_en.json
@@ -51,6 +51,7 @@
   "cosmosResourceModule.addResource",
   "cosmosResourceModule.createCosmosRes",
   "cosmosResourceModule.internalName",
+  "footer.license",
   "footer.back",
   "footer.next",
   "footer.generate",

--- a/src/extension/src/constants.ts
+++ b/src/extension/src/constants.ts
@@ -183,9 +183,6 @@ export const CONSTANTS = {
   PORT: 5000,
   VSCODE_COMMAND: {
     OPEN_FOLDER: "vscode.openFolder"
-  },
-  PLATFORM: {
-    WIN_32: "win32"
   }
 };
 

--- a/src/extension/src/controller.ts
+++ b/src/extension/src/controller.ts
@@ -1,7 +1,4 @@
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
-import * as os from "os";
 import { Validator } from "./utils/validator";
 import {
   CONSTANTS,
@@ -81,13 +78,6 @@ export class Controller {
   public async launchWizard(
     context: vscode.ExtensionContext
   ): Promise<ChildProcess> {
-    if (os.platform() !== CONSTANTS.PLATFORM.WIN_32) {
-      const enginePath = path.resolve(
-        this.context.extensionPath,
-        CONSTANTS.ENGINE_DIRECTORY
-      );
-      fs.chmodSync(enginePath, 0o755);
-    }
     let process = ApiModule.StartApi(context);
     let syncObject: ISyncReturnType = {
       successfullySynced: false,

--- a/src/extension/src/signalr-api-module/apiModule.ts
+++ b/src/extension/src/signalr-api-module/apiModule.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as os from "os";
+import * as fs from "fs";
 import { ChildProcess, execFile } from "child_process";
 import { CONSTANTS } from "../constants";
 import { ICommandPayload } from "./commandPayload";
@@ -30,6 +32,10 @@ export default class ApiModule {
       "api",
       platform
     );
+
+    if (os.platform() !== CONSTANTS.API.WINDOWS_PLATFORM_VERSION) {
+      fs.chmodSync(apiPath, 0o755);
+    }
 
     let spawnedProcess = execFile(`${apiPath}`, { cwd: apiWorkingDirectory });
     ApiModule._process = spawnedProcess;

--- a/src/extension/src/utils/validator.ts
+++ b/src/extension/src/utils/validator.ts
@@ -10,7 +10,10 @@ export class Validator extends WizardServant {
     (message: any) => Promise<IPayloadResponse>
   > = new Map([
     [ExtensionCommand.GetOutputPath, Validator.sendOutputPathSelectionToClient],
-    [ExtensionCommand.ProjectPathValidation, Validator.handleProjectPathValidation]
+    [
+      ExtensionCommand.ProjectPathValidation,
+      Validator.handleProjectPathValidation
+    ]
   ]);
 
   public static async sendOutputPathSelectionToClient(
@@ -26,7 +29,7 @@ export class Validator extends WizardServant {
         let path = undefined;
 
         if (res !== undefined) {
-          if (process.platform === CONSTANTS.PLATFORM.WIN_32) {
+          if (process.platform === CONSTANTS.API.WINDOWS_PLATFORM_VERSION) {
             path = res[0].path.substring(1, res[0].path.length);
           } else {
             path = res[0].path;
@@ -40,7 +43,9 @@ export class Validator extends WizardServant {
       });
   }
 
-  public static async handleProjectPathValidation(message: any): Promise<IPayloadResponse> {
+  public static async handleProjectPathValidation(
+    message: any
+  ): Promise<IPayloadResponse> {
     const projectPath = message.projectPath;
     const projectName = message.projectName;
 
@@ -80,9 +85,9 @@ export class Validator extends WizardServant {
       isValid: isValid,
       error: error
     };
-  }
+  };
 
   private static isUniquePath = (projectPath: string, name: string) => {
     return !fs.existsSync(path.join(projectPath, name));
-  }
+  };
 }


### PR DESCRIPTION
For Mac OS and Linux, files are, by default, not executable.

That means when the extension starts, Core will fail to run.

This PR uses Node to apply executable permissions (+x) to the Core, allowing it to run without user intervention.

Tested on Mac OS X.

Closes #285 