### PR TITLE
sidebar dropdown license bug

### DIFF
--- a/src/client/src/components/RightSidebarDropdown/index.tsx
+++ b/src/client/src/components/RightSidebarDropdown/index.tsx
@@ -4,17 +4,20 @@ import Dropdown from "../../components/Dropdown";
 
 import styles from "./styles.module.css";
 import { ISelected } from "../../types/selected";
+import { IOption } from "../../types/option";
 
 interface IProps {
   handleDropdownChange: (
     dropdownTitle: IDropDownOptionType,
-    selectDropdownOption: (dropDrownItem: ISelected) => void
+    selectDropdownOption: (dropDrownItem: ISelected) => void,
+    optionsData: IOption[]
   ) => void;
   selectDropdownOption: (dropDrownItem: ISelected) => void;
   options: IDropDownOptionType[];
   title: string;
   isVisible: boolean;
   value: IDropDownOptionType;
+  optionsData: IOption[];
 }
 
 const RightSidebarDropdown = (props: IProps) => {
@@ -27,7 +30,8 @@ const RightSidebarDropdown = (props: IProps) => {
             handleChange={dropDrownItem => {
               props.handleDropdownChange(
                 dropDrownItem,
-                props.selectDropdownOption
+                props.selectDropdownOption,
+                props.optionsData
               );
             }}
             options={props.options}

--- a/src/client/src/containers/RightSidebar/strings.ts
+++ b/src/client/src/containers/RightSidebar/strings.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  yourProjectDetails: {
+    id: "rightSidebar.yourProjectDetails",
+    defaultMessage: "Your Project Details"
+  },
+  projectType: {
+    id: "rightSidebar.projectType",
+    defaultMessage: "Project Type"
+  },
+  frontendFramework: {
+    id: "rightSidebar.frontendFramework",
+    defaultMessage: "Front-end Framework"
+  },
+  backendFramework: {
+    id: "rightSidebar.backendFramework",
+    defaultMessage: "Back-end Framework"
+  },
+  services: {
+    id: "rightSidebar.services",
+    defaultMessage: "Services"
+  }
+});
+
+export default messages;

--- a/src/client/src/reducers/wizardContentReducers/index.ts
+++ b/src/client/src/reducers/wizardContentReducers/index.ts
@@ -5,10 +5,13 @@ import pageOptions from "./pagesOptionsReducer";
 import projectTypes from "./projectTypeReducer";
 import detailsPage from "./detailsPageReducer";
 
-export default combineReducers({
+const wizardContentReducer = combineReducers({
   backendOptions,
   frontendOptions,
   pageOptions,
   projectTypes,
   detailsPage
 });
+
+export default wizardContentReducer;
+export type WizardContentType = ReturnType<typeof wizardContentReducer>;


### PR DESCRIPTION
When a change is made to the wizard in the right sidebar dropdown menus, all selection data required to display licenses and versioning is appended during the change event.

Closes #422 