### PR TITLE
remove overwriting of azure function names when add/remove functions

### DIFF
--- a/src/client/src/containers/AzureFunctionsModal/styles.module.css
+++ b/src/client/src/containers/AzureFunctionsModal/styles.module.css
@@ -45,6 +45,10 @@
   height: 12px;
 }
 
+.icon path {
+  fill: var(--vscode-editor-foreground);
+}
+
 .validationIcon {
   height: 15px;
   margin-right: 0.2em;

--- a/src/client/src/containers/CosmosResourceModal/styles.module.css
+++ b/src/client/src/containers/CosmosResourceModal/styles.module.css
@@ -43,6 +43,10 @@
   height: 12px;
 }
 
+.icon path {
+  fill: var(--vscode-editor-foreground);
+}
+
 .validationIcon {
   height: 15px;
   margin-right: 0.2em;

--- a/src/client/src/reducers/wizardSelectionReducers/services/azureFunctionsReducer.ts
+++ b/src/client/src/reducers/wizardSelectionReducers/services/azureFunctionsReducer.ts
@@ -54,7 +54,29 @@ const initialState = {
   }
 };
 
-const createFunctionNames = (numFunctions: number): string[] => {
+const createFunctionNames = (
+  numFunctions: number,
+  prevFunctionNames?: string[]
+): string[] => {
+  if (prevFunctionNames) {
+    if (prevFunctionNames.length >= numFunctions) {
+      const numFunctionsToDelete = prevFunctionNames.length - numFunctions;
+      const startIndex = prevFunctionNames.length - numFunctionsToDelete;
+      prevFunctionNames.splice(startIndex, numFunctionsToDelete);
+    } else {
+      const numFunctionsToCreate = numFunctions - prevFunctionNames.length;
+      let lastNumberUsed = 1;
+      for (let i = 1; i <= numFunctionsToCreate; i++) {
+        let functionName = `function${lastNumberUsed}`;
+        while (prevFunctionNames.includes(functionName)) {
+          lastNumberUsed++;
+          functionName = `function${lastNumberUsed}`;
+        }
+        prevFunctionNames.push(functionName);
+      }
+    }
+    return [...prevFunctionNames];
+  }
   const functionNames = [];
   for (let i = 1; i <= numFunctions; i++) {
     functionNames.push(`function${i}`);
@@ -116,7 +138,8 @@ const azureFunctions = (
             internalName: action.payload.internalName.value,
             numFunctions: action.payload.numFunctions.value,
             functionNames: createFunctionNames(
-              action.payload.numFunctions.value
+              action.payload.numFunctions.value,
+              state.selection[0] ? state.selection[0].functionNames : undefined
             ),
             appName: action.payload.appName.value
           }


### PR DESCRIPTION
Changes the behaviour of Azure Function Names when modifying the number of functions taken.

- Makes sure all function names are unique (no duplicate function names)
- Retains function names that have been changed but not removed

Closes #404 