### PR TITLE
decrease count of function names when deleting a function

### DIFF
--- a/src/client/src/reducers/wizardSelectionReducers/services/azureFunctionsReducer.ts
+++ b/src/client/src/reducers/wizardSelectionReducers/services/azureFunctionsReducer.ts
@@ -103,6 +103,7 @@ const azureFunctions = (
       const newFunctionState = { ...state };
       if (newFunctionState.selection[0].functionNames) {
         newFunctionState.selection[0].functionNames.splice(action.payload, 1);
+        newFunctionState.selection[0].numFunctions--;
       }
       return newFunctionState;
     case AZURE_TYPEKEYS.SAVE_AZURE_FUNCTIONS_SETTINGS:


### PR DESCRIPTION
Bug fix: Decreases the count of the number of functions when deleting an Azure Function by changing the redux state storing the number of functions.

Closes #469 