### PR TITLE
fix azure functions renaming bug - rightsidebar

### DIFF
--- a/src/client/src/components/DraggableSidebarItem/index.tsx
+++ b/src/client/src/components/DraggableSidebarItem/index.tsx
@@ -36,7 +36,8 @@ const DraggableSidebarItem = ({
   withLargeIndent,
   handleCloseClick,
   intl,
-  customInputStyle
+  customInputStyle,
+  isAzureFunction
 }: {
   page?: ISelected;
   text?: string;
@@ -52,6 +53,7 @@ const DraggableSidebarItem = ({
   handleCloseClick?: (idx: number) => void;
   intl: InjectedIntl;
   customInputStyle?: string;
+  isAzureFunction?: boolean;
 }) => {
   const handleKeyDown = (event: any) => {
     if (event.keyCode === 13 || event.keyCode === 32) {
@@ -96,11 +98,11 @@ const DraggableSidebarItem = ({
                 (getSvg(page!.internalName, styles.icon) || (
                   <img className={styles.icon} src={pageSvgUrl} />
                 ))}
-              {handleInputChange && (page || azureFunctionName) && idx && (
+              {handleInputChange && (page || isAzureFunction) && idx && (
                 <input
                   aria-label={intl.formatMessage(messages.changeItemName)}
                   className={classnames(styles.input, {
-                    [styles.azureFunctionNameInput]: azureFunctionName
+                    [styles.azureFunctionNameInput]: isAzureFunction
                   })}
                   value={page ? page.title : azureFunctionName!.title}
                   onChange={e => {

--- a/src/client/src/containers/AzureFunctionsSelection/index.tsx
+++ b/src/client/src/containers/AzureFunctionsSelection/index.tsx
@@ -148,6 +148,7 @@ const AzureFunctionsSelection = ({
                       closeSvgUrl={getSvg.getCancelSvg()}
                       withLargeIndent={true}
                       azureFunctionName={functionName}
+                      isAzureFunction={true}
                       handleInputChange={handleInputChange}
                       idx={idx + 1}
                       handleCloseClick={removeAzureFunction}


### PR DESCRIPTION
Uses a boolean to determine if the azure functions input field should render, rather than the truthiness/falsiness of the function name itself.

The bug occurs when an empty string is used as the truthy/falsy value, which means that an empty string will cause the input field to not render and make the string uneditable.

Closes #475 