### PR TITLE
add custom input styling to azure functions and cosmos rightsidebar

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -52,7 +52,7 @@ import { setAzureValidationStatusAction } from "./actions/azureActions/setAzureV
 import { IServiceStatus } from "./reducers/generationStatus/genStatus";
 
 if (process.env.NODE_ENV === DEVELOPMENT) {
-  require("./css/themeslight.css");
+  require("./css/themes.css");
 }
 
 interface IDispatchProps {

--- a/src/client/src/components/DraggableSidebarItem/index.tsx
+++ b/src/client/src/components/DraggableSidebarItem/index.tsx
@@ -34,7 +34,8 @@ const DraggableSidebarItem = ({
   withIndent,
   withLargeIndent,
   handleCloseClick,
-  intl
+  intl,
+  customInputStyle
 }: {
   page?: ISelected;
   text?: string;
@@ -49,6 +50,7 @@ const DraggableSidebarItem = ({
   withLargeIndent?: boolean;
   handleCloseClick?: (idx: number) => void;
   intl: InjectedIntl;
+  customInputStyle?: string;
 }) => {
   const handleKeyDown = (event: any) => {
     if (event.keyCode === 13 || event.keyCode === 32) {
@@ -82,7 +84,7 @@ const DraggableSidebarItem = ({
         </div>
         <div className={styles.errorStack}>
           <div
-            className={classnames({
+            className={classnames(customInputStyle, {
               [styles.pagesTextContainer]: withIndent || reorderSvgUrl,
               [styles.textContainer]: !withIndent,
               [styles.largeIndentContainer]: withLargeIndent

--- a/src/client/src/containers/AzureFunctionsSelection/index.tsx
+++ b/src/client/src/containers/AzureFunctionsSelection/index.tsx
@@ -94,6 +94,7 @@ const AzureFunctionsSelection = ({
                 </div>
               </div>
               <DraggableSidebarItem
+                customInputStyle={styles.input}
                 key={functionApp.appName + idx}
                 text={functionApp.appName}
                 closeSvgUrl={getSvg.getCancelSvg()}

--- a/src/client/src/containers/AzureFunctionsSelection/styles.module.css
+++ b/src/client/src/containers/AzureFunctionsSelection/styles.module.css
@@ -17,3 +17,8 @@
 .edit:focus {
   outline: 1px solid var(--vscode-contrastActiveBorder);
 }
+
+.input {
+  background-color: var(--vscode-sideBar-background);
+  color: var(--vscode-editor-foreground);
+}

--- a/src/client/src/containers/CosmosDBSelection/index.tsx
+++ b/src/client/src/containers/CosmosDBSelection/index.tsx
@@ -64,6 +64,7 @@ const CosmosDBSelection = ({
             const { accountName } = resource;
             return (
               <DraggableSidebarItem
+                customInputStyle={styles.input}
                 key={accountName}
                 text={accountName}
                 closeSvgUrl={getSvg.getCancelSvg()}

--- a/src/client/src/containers/CosmosDBSelection/styles.module.css
+++ b/src/client/src/containers/CosmosDBSelection/styles.module.css
@@ -17,3 +17,8 @@
 .edit:focus {
   outline: 1px solid var(--vscode-contrastActiveBorder);
 }
+
+.input {
+  color: var(--vscode-editor-foreground);
+  background-color: var(--vscode-sideBar-background);
+}


### PR DESCRIPTION
Add custom input styling to righthand sidebar inputs so that cosmos selection and azure functions selection show a separation between editable non-editable fields.

Closes #311 