### PR TITLE
fix output path css so that it does not expand when output path is very long

### DIFF
--- a/src/client/src/appStyles.module.css
+++ b/src/client/src/appStyles.module.css
@@ -13,6 +13,7 @@
   height: calc(100vh - 122px);
   margin-top: 51px;
   margin-bottom: 71px;
+  justify-content: center;
 }
 
 .centerViewMaxHeight {

--- a/src/client/src/components/OutputPath/styles.module.css
+++ b/src/client/src/components/OutputPath/styles.module.css
@@ -41,6 +41,7 @@
   padding: 0px 10px;
   opacity: 50%;
   min-height: 38px;
+  overflow: auto;
 }
 
 .errorStack {

--- a/src/client/src/containers/Welcome/styles.module.css
+++ b/src/client/src/containers/Welcome/styles.module.css
@@ -1,8 +1,9 @@
 .container {
     align-self: center;
     width: 100%;
-    margin-left: 20%;
-    margin-right: 20%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .container>div {
@@ -34,8 +35,8 @@
     align-items: center;
     flex-direction: column;
     justify-content: flex-end;
-    padding: 0px 15% 0px 15%;
     box-sizing: border-box;
+    width: 50%;
 }
 
 .getStarted {


### PR DESCRIPTION
Change css to properly use flexbox so that it is bounded properly when output path is very long.

Also sets the error message to overflow: auto so that if the output path is very long, the error box becomes scrollable and doesn't exceed the div.

Closes #330 