### PR TITLE
added vscode mocks

### DIFF
--- a/mocks/vscode/extensions.json
+++ b/mocks/vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    // Engine: Add if Azure Functions selected
+    "ms-azuretools.vscode-azurefunctions",
+    // Engine: Add if Cosmos DB selected
+    "ms-azuretools.vscode-cosmosdb"
+  ]
+}

--- a/mocks/vscode/extensions.json
+++ b/mocks/vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "msjsdiag.debugger-for-chrome",
     // Engine: Add if Azure Functions selected
     "ms-azuretools.vscode-azurefunctions",
     // Engine: Add if Cosmos DB selected

--- a/mocks/vscode/launch.json
+++ b/mocks/vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Frontend",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/react-scripts",
+      "args": ["--inspect-brk=9230", "start"],
+      "cwd": "${workspaceFolder}",
+      "internalConsoleOptions": "neverOpen",
+      "preLaunchTask": "frontend-install",
+      "port": 9230
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Server",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/nodemon",
+      "runtimeArgs": ["--inspect-brk=9231"],
+      "program": "${workspaceFolder}/server/server.js",
+      "restart": true,
+      "internalConsoleOptions": "neverOpen",
+      "preLaunchTask": "server-install",
+      "port": 9231
+    },
+    {
+      "name": "Attach to Node Functions",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "preLaunchTask": "func: host start"
+    }
+  ]
+}

--- a/mocks/vscode/launch.json
+++ b/mocks/vscode/launch.json
@@ -1,15 +1,21 @@
 {
   "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "Launch Frontend and Debug Server",
+      "configurations": ["Launch Frontend", "Debug Server"]
+    }
+  ],
   "configurations": [
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Frontend",
+      "name": "Launch Frontend",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/react-scripts",
       "args": ["--inspect-brk=9230", "start"],
       "cwd": "${workspaceFolder}",
-      "internalConsoleOptions": "neverOpen",
       "preLaunchTask": "frontend-install",
+      "internalConsoleOptions": "neverOpen",
       "port": 9230
     },
     {
@@ -21,9 +27,9 @@
       "program": "${workspaceFolder}/server/server.js",
       "restart": true,
       "internalConsoleOptions": "neverOpen",
-      "preLaunchTask": "server-install",
       "port": 9231
     },
+    // Engine: Add if azure functions is selected
     {
       "name": "Attach to Node Functions",
       "type": "node",

--- a/mocks/vscode/settings.json
+++ b/mocks/vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  // Engine: Add azureFunctions.* if azure functions selected
+  "azureFunctions.projectRuntime": "~2",
+  "azureFunctions.projectLanguage": "JavaScript",
+  // Engine: change `appName` to users azure functions appName
+  "azureFunctions.deploySubpath": "appName",
+  "azureFunctions.preDeployTask": "func: extensions install",
+  "files.exclude": {
+    "obj": true,
+    "bin": true
+  },
+  "debug.internalConsoleOptions": "neverOpen"
+}

--- a/mocks/vscode/tasks.json
+++ b/mocks/vscode/tasks.json
@@ -1,6 +1,7 @@
 {
   "version": "2.0.0",
   "tasks": [
+    // Engine: Add if azure functions is selected
     {
       "type": "func",
       "command": "host start",
@@ -13,21 +14,10 @@
       }
     },
     {
-      "label": "server-install",
-      "type": "npm",
-      "script": "install",
-      "path": "server/",
-      "problemMatcher": []
-    },
-    {
       "label": "frontend-install",
       "type": "npm",
       "script": "install",
       "problemMatcher": []
-    },
-    {
-      "label": "dependency-install",
-      "dependsOn": ["server-install", "frontend-install"]
     }
   ]
 }

--- a/mocks/vscode/tasks.json
+++ b/mocks/vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "func",
+      "command": "host start",
+      "problemMatcher": "$func-watch",
+      "dependsOn": "func: extensions install",
+      "isBackground": true,
+      "options": {
+        // Engine: change `appName` to users azure functions appName
+        "cwd": "${workspaceFolder}/appName"
+      }
+    },
+    {
+      "label": "server-install",
+      "type": "npm",
+      "script": "install",
+      "path": "server/",
+      "problemMatcher": []
+    },
+    {
+      "label": "frontend-install",
+      "type": "npm",
+      "script": "install",
+      "problemMatcher": []
+    },
+    {
+      "label": "dependency-install",
+      "dependsOn": ["server-install", "frontend-install"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds mocks for .VSCode config. This allows our users to run both the server and the frontend from top level directory and debug the server too! 

_**Testing Notes:**_

- Generate a project with WebTS
- Add the VSCode folder under mocks to your project as .VSCode
- Open your project in VSCode
- Open the debug menu from the VSCode sidebar on the left side of VSCode
- Run both *Debug Frontend* and *Debug Server* configs
- Test out debugging the server using breakpoints 

## Debugging frontend 

You can't debug React or Angular with this config since it has a dependency on https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome and if we want to add it as an extension dependency with WebTS still needs to be discussed.

## Running both the processes at once 

The current config then requires the user to run 2 processes at once (one for server and one for client). Technically this could be done through one config running both (by calling a debug version of `npm start`) but *concurrently*, the library being used to run both at same time doesn't dispose the server properly so this would be another issue.

## Yarn vs NPM

While we could support both yarn and NPM as our package manager, this decision should come from the user through the wizard and a config generated accordingly using CoreTS instead of us trying to support both at the same time. The VSCode configs don't have conditional logic (as they're simple JSON configs) so the only way to handle both is to use a conditional shell command (like `yarn install || npm install`) which is bad practice. For now, we would ship with *npm* since more users should have it versus yarn.

Closes #412 