### PR TITLE
update css font variables

### DIFF
--- a/src/client/src/components/Card/styles.module.css
+++ b/src/client/src/components/Card/styles.module.css
@@ -27,7 +27,7 @@
 
 .signInButton {
   margin-left: 10px;
-  font-size: var(--vscode-editor-font-size);
+  font-size: var(--vscode-font-size);
   border: none;
 }
 

--- a/src/client/src/components/Details/styles.module.css
+++ b/src/client/src/components/Details/styles.module.css
@@ -94,7 +94,7 @@
 
 .link {
   color: var(--vscode-textLink-foreground);
-  font-weight: var(--vscode-editor-font-weight);
+  font-weight: var(--vscode-font-weight);
   text-decoration: none;
 }
 

--- a/src/client/src/components/LoginCard/styles.module.css
+++ b/src/client/src/components/LoginCard/styles.module.css
@@ -10,7 +10,7 @@
   align-items: center;
   justify-content: space-between;
   color: var(--vscode-textLink-foreground);
-  font-size: var(--vscode-editor-font-size);
+  font-size: var(--vscode-font-size);
 }
 
 .createAccountButton {

--- a/src/client/src/containers/Licenses/styles.module.css
+++ b/src/client/src/containers/Licenses/styles.module.css
@@ -11,9 +11,9 @@
 
 .link {
   text-decoration: none;
-  font-size: var(--vscode-editor-font-size);
+  font-size: var(--vscode-font-size);
   color: var(--vscode-textLink-foreground);
-  font-weight: var(--vscode-editor-font-weight);
+  font-weight: var(--vscode-font-weight);
   margin-left: 10px;
 }
 

--- a/src/client/src/containers/PostGenerationModal/styles.module.css
+++ b/src/client/src/containers/PostGenerationModal/styles.module.css
@@ -100,7 +100,7 @@
 
 .link {
   color: var(--vscode-textLink-foreground);
-  font-weight: var(--vscode-editor-font-weight);
+  font-weight: var(--vscode-font-weight);
   text-decoration: none;
   font-size: 14px;
 }

--- a/src/client/src/containers/SortablePageList/styles.module.css
+++ b/src/client/src/containers/SortablePageList/styles.module.css
@@ -21,7 +21,7 @@
   padding-right: 1px;
   padding-left: 1px;
   border: none;
-  font-size: var(--vscode-editor-font-size);
+  font-size: var(--vscode-font-size);
   background-color: var(--vscode-editor-background);
 }
 

--- a/src/client/src/css/grid.module.css
+++ b/src/client/src/css/grid.module.css
@@ -13,19 +13,19 @@ body {
   padding: 0;
   left: 0;
   top: 0;
-  font-size: var(--vscode-editor-font-size);
+  font-size: var(--vscode-font-size);
   color: var(--vscode-editor-foreground);
-  font-weight: var(--vscode-editor-font-weight);
+  font-weight: var(--vscode-font-weight);
 }
 
 a {
-  font-weight: var(--vscode-editor-font-weight);
+  font-weight: var(--vscode-font-weight);
 }
 
 /* ROOT FONT STYLES */
 
 * {
-  font-family: var(--vscode-editor-font-family);
+  font-family: var(--vscode-font-family);
   line-height: 1.5;
 }
 
@@ -56,8 +56,8 @@ h6 {
 }
 
 p {
-  font-size: var(--vscode-editor-font-size);
-  font-weight: var(--vscode-editor-font-weight);
+  font-size: var(--vscode-font-size);
+  font-weight: var(--vscode-font-weight);
   margin: 0px;
 }
 
@@ -186,6 +186,7 @@ p {
 }
 
 @media only screen and (min-width: 33.75em) {
+
   /* 540px */
   .container {
     width: 80%;
@@ -193,6 +194,7 @@ p {
 }
 
 @media only screen and (min-width: 45em) {
+
   /* 720px */
   .col1 {
     width: 4.33%;
@@ -248,6 +250,7 @@ p {
 }
 
 @media only screen and (min-width: 60em) {
+
   /* 960px */
   .container {
     width: 75%;

--- a/src/client/src/css/themes.css
+++ b/src/client/src/css/themes.css
@@ -28,15 +28,13 @@
   --vscode-editor-findMatchBackground: #515c6a;
   --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
   --vscode-editor-findRangeHighlightBackground: rgba(58, 61, 65, 0.4);
-  --vscode-editor-focusedStackFrameHighlightBackground: rgba(
-    122,
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(122,
     189,
     122,
-    0.3
-  );
-  --vscode-editor-font-family: -apple-system, system-ui, sans-serif;
-  --vscode-editor-font-size: 13px;
-  --vscode-editor-font-weight: 400;
+    0.3);
+  --vscode-font-family: -apple-system, system-ui, sans-serif;
+  --vscode-font-size: 13px;
+  --vscode-font-weight: 400;
   --vscode-editor-foreground: #d4d4d4;
   --vscode-editor-hoverHighlightBackground: rgba(38, 79, 120, 0.25);
   --vscode-editor-inactiveSelectionBackground: #3a3d41;
@@ -82,43 +80,33 @@
   --vscode-editorOverviewRuler-border: rgba(127, 127, 127, 0.3);
   --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
   --vscode-editorOverviewRuler-commonContentForeground: rgba(96, 96, 96, 0.4);
-  --vscode-editorOverviewRuler-currentContentForeground: rgba(
-    64,
+  --vscode-editorOverviewRuler-currentContentForeground: rgba(64,
     200,
     174,
-    0.5
-  );
+    0.5);
   --vscode-editorOverviewRuler-deletedForeground: rgba(0, 122, 204, 0.6);
   --vscode-editorOverviewRuler-errorForeground: rgba(255, 18, 18, 0.7);
   --vscode-editorOverviewRuler-findMatchForeground: rgba(246, 185, 77, 0.7);
-  --vscode-editorOverviewRuler-incomingContentForeground: rgba(
-    64,
+  --vscode-editorOverviewRuler-incomingContentForeground: rgba(64,
     166,
     255,
-    0.5
-  );
+    0.5);
   --vscode-editorOverviewRuler-infoForeground: rgba(18, 18, 136, 0.7);
   --vscode-editorOverviewRuler-modifiedForeground: rgba(0, 122, 204, 0.6);
   --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
-  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(160,
     160,
     160,
-    160,
-    0.8
-  );
+    0.8);
   --vscode-editorOverviewRuler-warningForeground: rgba(18, 136, 18, 0.7);
-  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(160,
     160,
     160,
-    160,
-    0.8
-  );
-  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
-    192,
+    0.8);
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(192,
     160,
     192,
-    0.8
-  );
+    0.8);
   --vscode-editorPane-background: #1e1e1e;
   --vscode-editorRuler-foreground: #5a5a5a;
   --vscode-editorSuggestWidget-background: #252526;

--- a/src/client/src/css/themeslight.css
+++ b/src/client/src/css/themeslight.css
@@ -28,15 +28,13 @@
   --vscode-editor-findMatchBackground: #a8ac94;
   --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
   --vscode-editor-findRangeHighlightBackground: rgba(180, 180, 180, 0.3);
-  --vscode-editor-focusedStackFrameHighlightBackground: rgba(
-    206,
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(206,
     231,
     206,
-    0.45
-  );
-  --vscode-editor-font-family: -apple-system, system-ui, sans-serif;
-  --vscode-editor-font-size: 13px;
-  --vscode-editor-font-weight: 400;
+    0.45);
+  --vscode-font-family: -apple-system, system-ui, sans-serif;
+  --vscode-font-size: 13px;
+  --vscode-font-weight: 400;
   --vscode-editor-foreground: #000000;
   --vscode-editor-hoverHighlightBackground: rgba(173, 214, 255, 0.15);
   --vscode-editor-inactiveSelectionBackground: #e5ebf1;
@@ -82,43 +80,33 @@
   --vscode-editorOverviewRuler-border: rgba(127, 127, 127, 0.3);
   --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
   --vscode-editorOverviewRuler-commonContentForeground: rgba(96, 96, 96, 0.4);
-  --vscode-editorOverviewRuler-currentContentForeground: rgba(
-    64,
+  --vscode-editorOverviewRuler-currentContentForeground: rgba(64,
     200,
     174,
-    0.5
-  );
+    0.5);
   --vscode-editorOverviewRuler-deletedForeground: rgba(0, 122, 204, 0.6);
   --vscode-editorOverviewRuler-errorForeground: rgba(255, 18, 18, 0.7);
   --vscode-editorOverviewRuler-findMatchForeground: rgba(246, 185, 77, 0.7);
-  --vscode-editorOverviewRuler-incomingContentForeground: rgba(
-    64,
+  --vscode-editorOverviewRuler-incomingContentForeground: rgba(64,
     166,
     255,
-    0.5
-  );
+    0.5);
   --vscode-editorOverviewRuler-infoForeground: rgba(18, 18, 136, 0.7);
   --vscode-editorOverviewRuler-modifiedForeground: rgba(0, 122, 204, 0.6);
   --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
-  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(160,
     160,
     160,
-    160,
-    0.8
-  );
+    0.8);
   --vscode-editorOverviewRuler-warningForeground: rgba(18, 136, 18, 0.7);
-  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(160,
     160,
     160,
-    160,
-    0.8
-  );
-  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
-    192,
+    0.8);
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(192,
     160,
     192,
-    0.8
-  );
+    0.8);
   --vscode-editorPane-background: #ffffff;
   --vscode-editorRuler-foreground: #d3d3d3;
   --vscode-editorSuggestWidget-background: #f3f3f3;

--- a/src/client/src/translations/whitelist_en.json
+++ b/src/client/src/translations/whitelist_en.json
@@ -69,6 +69,7 @@
   "cosmosResourceModule.saveChanges",
   "cosmosResourceModule.createCosmosRes",
   "cosmosResourceModule.internalName",
+  "footer.license",
   "footer.back",
   "footer.next",
   "footer.generate",


### PR DESCRIPTION
Updates CSS font weights/family/sizes to work with VSCode v1.34.

This should also work on VSCode v1.33.

Please check all the views of the extension to make sure everything looks correct, otherwise let's close this PR and wait until v1.34 is released.

**Please test on VSCode v1.33 and [VSCode Insiders](https://code.visualstudio.com/insiders/)**

Closes #435 