### PR TITLE
Removed empty error message while entering account name

### DIFF
--- a/src/client/src/containers/AzureFunctionsModal/index.tsx
+++ b/src/client/src/containers/AzureFunctionsModal/index.tsx
@@ -227,6 +227,7 @@ const AzureFunctionsResourceModal = (props: Props) => {
    * Listens on account name change and validates the input in VSCode
    */
   React.useEffect(() => {
+    if (azureFunctionsFormData.appName.value != "") {
       if (timeout) {
         clearTimeout(timeout);
       }
@@ -240,6 +241,7 @@ const AzureFunctionsResourceModal = (props: Props) => {
           subscription: azureFunctionsFormData.subscription.value
         });
       }, 700);
+    }
   }, [azureFunctionsFormData.appName]);
 
   React.useEffect(() => {

--- a/src/client/src/containers/CosmosResourceModal/index.tsx
+++ b/src/client/src/containers/CosmosResourceModal/index.tsx
@@ -224,6 +224,7 @@ const CosmosResourceModal = (props: Props) => {
    * Listens on account name change and validates the input in VSCode
    */
   React.useEffect(() => {
+    if (cosmosFormData.accountName.value != "") {
       if (timeout) {
         clearTimeout(timeout);
       }
@@ -237,6 +238,7 @@ const CosmosResourceModal = (props: Props) => {
           subscription: cosmosFormData.subscription.value
         });
       }, 700);
+    }
   }, [cosmosFormData.accountName]);
 
   React.useEffect(() => {


### PR DESCRIPTION
When adding an Account name in the Functions or Cosmos Modal a blank error message no longer appears. Also added a few helpful comments!

Closes #555 