### PR TITLE
make sure that only editable prop works on double click

### DIFF
--- a/src/client/src/components/SummaryTile/index.tsx
+++ b/src/client/src/components/SummaryTile/index.tsx
@@ -83,7 +83,9 @@ const SummaryTile = ({
     setTitle(target.value);
   };
   const handleClick = () => {
-    setDisabled(false);
+    if (isEditable && !canDelete) {
+      setDisabled(false);
+    }
   };
   const handleFocusOut = () => {
     setDisabled(true);

--- a/src/client/src/translations/whitelist_en.json
+++ b/src/client/src/translations/whitelist_en.json
@@ -80,7 +80,6 @@
   "postGenerationModal.restartWizard",
   "postGenerationModal.deploymentFailure",
   "postGenerationModal.closeWizard",
-  "postGenerationModal.success",
   "postGenerationModal.isDeploying",
   "postGenerationModal.working",
   "postGenerationModal.unknownStatus",


### PR DESCRIPTION
Uses additional "Editable" booleans to make sure double-click to edit only works on pages and function names. 

Closes #563 