### PR TITLE
Vue master detail page implementation

### DIFF
--- a/templates/Web/Pages/Vue.MasterDetail/.template.config/description.md
+++ b/templates/Web/Pages/Vue.MasterDetail/.template.config/description.md
@@ -1,0 +1,1 @@
+﻿The master-detail page has a master pane and a details pane for content. When an item in the master list is selected, the details pane is updated. This pattern is frequently used for email and address books.

--- a/templates/Web/Pages/Vue.MasterDetail/.template.config/icon.xaml
+++ b/templates/Web/Pages/Vue.MasterDetail/.template.config/icon.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+  <Canvas Width="48" Height="48">
+    <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Fill="#000000">
+      <Path.Data>
+        <PathGeometry Figures="M28.414 4H7V44H39V14.586ZM29 7.414 35.586 14H29ZM9 42V6H27V16H37V42Z" FillRule="NonZero"/>
+      </Path.Data>
+    </Path>
+  </Canvas>
+</Viewbox>

--- a/templates/Web/Pages/Vue.MasterDetail/.template.config/template.json
+++ b/templates/Web/Pages/Vue.MasterDetail/.template.config/template.json
@@ -1,0 +1,43 @@
+﻿{
+  "author": "Microsoft",
+  "classifications": ["Universal"],
+  "name": "Master Detail",
+  "groupIdentity": "wts.Page.MasterDetail",
+  "identity": "wts.Page.Vue.MasterDetail",
+  "description": "The master-detail page has a master pane and a details pane for content.",
+  "tags": {
+    "language": "Any",
+    "type": "item",
+    "wts.type": "page",
+    "wts.platform": "Web",
+    "wts.projecttype": "FullStackWebApp",
+    "wts.frontendframework": "Vue",
+    "wts.backendframework": "all",
+    "wts.version": "1.0.0",
+    "wts.displayOrder": "1",
+    "wts.genGroup": "0",
+    "wts.rightClickEnabled": "true",
+    "wts.licenses": "[Bootstrap](https://github.com/twbs/bootstrap/blob/master/LICENSE)"
+  },
+  "sourceName": "VueMasterDetail",
+  "preferNameDirectory": true,
+  "PrimaryOutputs": [],
+  "symbols": {
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
+    "wts.itemNamespace": {
+      "type": "parameter",
+      "replaces": "Param_ItemNamespace"
+    },
+    "baseclass": {
+      "type": "parameter",
+      "replaces": "System.ComponentModel.INotifyPropertyChanged"
+    },
+    "setter": {
+      "type": "parameter",
+      "replaces": "Param_Setter"
+    }
+  }
+}

--- a/templates/Web/Pages/Vue.MasterDetail/src/assets/GreyAvatar.svg
+++ b/templates/Web/Pages/Vue.MasterDetail/src/assets/GreyAvatar.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20 40C31.0457 40 40 31.0457 40 20C40 8.9543 31.0457 0 20 0C8.9543 0 0 8.9543 0 20C0 31.0457 8.9543 40 20 40Z" fill="black" fill-opacity="0.26"/>
+</svg>

--- a/templates/Web/Pages/Vue.MasterDetail/src/components/MasterDetailPage.vue
+++ b/templates/Web/Pages/Vue.MasterDetail/src/components/MasterDetailPage.vue
@@ -1,0 +1,58 @@
+﻿<template>
+  <div class="col">
+    <div class="row heading">
+      <div class="col">
+        <h3 class="ml-3 mb-4">{{textSampleData.title}}</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12 mt-3">
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumb bg-white">
+            <li class="breadcrumb-item">
+              <a class="breadCrumbLink" href="#">Master Detail</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">{{textSampleData.title}}</li>
+          </ol>
+        </nav>
+      </div>
+      <div class="col-md-8 col-12 ml-3 mb-5">
+        <p class="title">Status</p>
+        <p>{{textSampleData.status}}</p>
+        <p class="title">Order Date</p>
+        <p>{{textSampleData.orderDate}}</p>
+        <p class="title">Ship To</p>
+        <p>{{textSampleData.shipTo}}</p>
+        <p class="title">Order Total</p>
+        <p>{{textSampleData.orderTotal}}</p>
+        <p class="title">Description</p>
+        <p>{{textSampleData.longDescription}}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "MasterDetailPage",
+  props: {
+    textSampleData: Object
+  }
+};
+</script>
+
+<style scoped>
+.title {
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.breadCrumbLink {
+  color: #025fce;
+}
+
+.heading {
+  background-color: #cecece;
+  padding-top: 18em;
+}
+</style>

--- a/templates/Web/Pages/Vue.MasterDetail/src/components/MasterDetailSideBarTab.vue
+++ b/templates/Web/Pages/Vue.MasterDetail/src/components/MasterDetailSideBarTab.vue
@@ -1,0 +1,26 @@
+﻿<template>
+  <button
+    v-on:click="$emit('onDisplayTabClick', index)"
+    type="button"
+    class="list-group-item list-group-item-action styles.sidebarText"
+  >
+    <img src="../assets/GreyAvatar.svg" alt="Default Grey Avatar" class="mr-3">
+    {{tabText}}
+  </button>
+</template>
+
+<script>
+export default {
+  name: "MasterDetailSideBarTab",
+  props: {
+    tabText: String,
+    index: Number
+  }
+};
+</script>
+
+<style scoped>
+.sidebarText {
+  font-weight: 500;
+}
+</style>

--- a/templates/Web/Pages/Vue.MasterDetail/src/views/VueMasterDetail.vue
+++ b/templates/Web/Pages/Vue.MasterDetail/src/views/VueMasterDetail.vue
@@ -1,0 +1,97 @@
+﻿<template>
+  <div>
+    <main id="mainContent" class="container-fluid">
+      <div class="row">
+        <div class="col-2 p-0 border-right sidebar">
+          <div class="list-group list-group-flush border-bottom">
+            <MasterDetailSideBarTab
+              v-for="(textAssets, index) in masterDetailText"
+              v-on:onDisplayTabClick="handleDisplayTabClick"
+              v-bind:tabText="textAssets.title"
+              v-bind:index="index"
+              v-bind:key="textAssets.id"
+            />
+          </div>
+        </div>
+        <MasterDetailPage v-bind:textSampleData="masterDetailText[currentDisplayTabIndex]"/>
+      </div>
+    </main>
+    <WarningMessage
+      v-if="WarningMessageOpen"
+      v-on:onWarningClose="handleWarningClose"
+      v-bind:text="WarningMessageText"
+    />
+  </div>
+</template>
+
+<script>
+import CONSTANTS from "../constants";
+import MasterDetailPage from "../components/MasterDetailPage";
+import MasterDetailSideBarTab from "../components/MasterDetailSideBarTab";
+import WarningMessage from "../components/WarningMessage";
+
+export default {
+  name: "VueMasterDetail",
+
+  components: {
+    MasterDetailPage,
+    MasterDetailSideBarTab,
+    WarningMessage
+  },
+
+  data: function() {
+    return {
+      masterDetailText: [
+        {
+          paragraph: "",
+          title: "",
+          tabName: "",
+          id: 0
+        }
+      ],
+      currentDisplayTabIndex: 0,
+      WarningMessageOpen: false,
+      WarningMessageText: ""
+    };
+  },
+
+  created: function() {
+    this.fetchTextAssets();
+  },
+
+  methods: {
+    fetchTextAssets: function() {
+      fetch(CONSTANTS.ENDPOINT.MASTERDETAIL)
+        .then(response => {
+          if (!response.ok) {
+            throw Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then(result => {
+          this.masterDetailText = result;
+        })
+        .catch(error => {
+          this.WarningMessageOpen = true;
+          this.WarningMessageText = `${
+            CONSTANTS.ERROR_MESSAGE.MASTERDETAIL_GET
+          } ${error}`;
+        });
+    },
+    handleWarningClose: function() {
+      this.WarningMessageOpen = false;
+      this.WarningMessageText = "";
+    },
+    handleDisplayTabClick: function(id) {
+      this.currentDisplayTabIndex = id;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.sidebar {
+  /* full height - footer height - navbar height */
+  min-height: calc(100vh - 160px - 57px);
+}
+</style>

--- a/templates/Web/_composition/Vue/Page.Vue.AddConstantsMasterDetail/.template.config/template.json
+++ b/templates/Web/_composition/Vue/Page.Vue.AddConstantsMasterDetail/.template.config/template.json
@@ -1,0 +1,30 @@
+﻿{
+    "author": "Microsoft Community",
+    "classifications": [
+      "Universal"
+    ],
+    "name": "Page.Vue.AddConstantsMasterDetail",
+  "tags": {
+    "language": "Any",
+    "type": "item",
+    "wts.type": "composition",
+    "wts.platform": "Web",
+    "wts.compositionOrder": 4,
+    "wts.version": "1.0.0",
+    "wts.compositionFilter": "$frontendframework == Vue & identity == wts.Page.Vue.MasterDetail"
+  },
+    "sourceName": "wts.ItemName",
+    "preferNameDirectory": true,
+    "PrimaryOutputs": [
+    ],
+    "symbols": {
+      "wts.rootNamespace": {
+        "type": "parameter",
+        "replaces": "Param_RootNamespace"
+      },
+      "wts.itemNamespace": {
+        "type": "parameter",
+        "replaces": "Param_ItemNamespace"
+      }
+    }
+  }

--- a/templates/Web/_composition/Vue/Page.Vue.AddConstantsMasterDetail/src/constants$wts.Page.Vue.MasterDetail_gpostaction.js
+++ b/templates/Web/_composition/Vue/Page.Vue.AddConstantsMasterDetail/src/constants$wts.Page.Vue.MasterDetail_gpostaction.js
@@ -1,0 +1,16 @@
+﻿const CONSTANTS = {};
+
+CONSTANTS.ERROR_MESSAGE = {};
+//^^
+//{[{
+CONSTANTS.ERROR_MESSAGE.MASTERDETAIL_GET =
+  "Request to get master detail text failed:";
+//}]}
+
+CONSTANTS.ENDPOINT = {};
+//^^
+//{[{
+CONSTANTS.ENDPOINT.MASTERDETAIL = "/api/masterdetail";
+//}]}
+
+export default CONSTANTS;


### PR DESCRIPTION
Summary of changes:
Implements the master detail page for vue. You should now be able to generate a project with a masterdetail page!

Should be reviewed after #647

Just hit f5 and launch webts then hit generate! Dlls are in for windows and mac!
Related issues:
#199