### PR TITLE
Wizard does not start again until you re-open vscode

### DIFF
--- a/src/extension/src/controller.ts
+++ b/src/extension/src/controller.ts
@@ -224,7 +224,8 @@ export class Controller {
     }
   }
 
-  dispose() {
+  static dispose() {
     CoreTemplateStudio.DestroyInstance();
+    this._instance = undefined;
   }
 }

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -1,19 +1,17 @@
 import * as vscode from "vscode";
 import { Controller } from "./controller";
 
-var controller: Controller | undefined;
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "webTemplateStudioExtension.wizardLaunch",
       async () => {
-        controller = Controller.getInstance(context, Date.now());
+        Controller.getInstance(context, Date.now());
       }
     )
   );
 }
 
 export function deactivate() {
-  controller!.dispose();
-  controller = undefined;
+  Controller!.dispose();
 }

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -13,5 +13,5 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-  Controller!.dispose();
+  Controller.dispose();
 }


### PR DESCRIPTION
Task: https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/28964

**Change**
- The Controller instance needs to disposed when the react panel is disposed. This allows to start a fresh react panel if the wizard is launched again without closing the extension.

closes #756 