### PR TITLE
angular bootstrap styling

### DIFF
--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module.ts
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module.ts
@@ -1,6 +1,5 @@
 ﻿import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatIconModule } from '@angular/material/icon';
 
 import { GridComponent } from './grid.component';
 import { Param_SourceName_PascalRoutingModule } from './Param_SourceName_Kebab-routing.module';
@@ -15,7 +14,6 @@ import { WarningMessageModule } from '../../shared/warning-message/warning-messa
   imports: [
     CommonModule,
     WarningMessageModule,
-    MatIconModule,
     Param_SourceName_PascalRoutingModule
   ]
 })

--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.css
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.css
@@ -1,4 +1,0 @@
-.mat-icon {
-    width: 98px;
-    height: 77px;
-}

--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.html
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.html
@@ -1,5 +1,5 @@
-﻿<div >
-  <mat-icon svgIcon="grey-box" alt="Default Grey Box" class="mb-3"></mat-icon>
-  <h3>{{header}}</h3>
-  <p>{{description}}</p>
+﻿<div>
+  <img src="{{ image }}" alt="Default Grey Box" class="mb-3" />
+  <h3>{{ header }}</h3>
+  <p>{{ description }}</p>
 </div>

--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.ts
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid-box/grid-box.component.ts
@@ -10,10 +10,10 @@ export class GridBoxComponent implements OnInit {
   @Input() key: number;
   @Input() header: string;
   @Input() description: string;
+  @Input() image: string;
 
   constructor() { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
 
 }

--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid.component.html
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid.component.html
@@ -21,6 +21,7 @@
         [key]="textAssets.id"
         [header]="textAssets.title"
         [description]="textAssets.shortDescription"
+        [image]="GreyBox"
       >
       </app-grid-box>
     </div>

--- a/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid.component.ts
+++ b/templates/Web/Pages/Angular.Grid/src/app/app-shell/Param_SourceName_Kebab/grid.component.ts
@@ -1,6 +1,4 @@
 ﻿import { Component, OnInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { MatIconRegistry } from '@angular/material/icon';
 
 import { GridService, IGridTextItem } from './grid.service';
 
@@ -11,6 +9,7 @@ import { GridService, IGridTextItem } from './grid.service';
 })
 export class GridComponent implements OnInit {
 
+  GreyBox = require('../../../assets/GreyBox.svg') as string;
   WarningMessageText = 'Request to get grid text failed:';
   WarningMessageOpen = false;
   gridTextAssets: IGridTextItem[] = [
@@ -25,11 +24,7 @@ export class GridComponent implements OnInit {
       id: 1
     }
   ];
-  constructor(private gridService: GridService, iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {
-    iconRegistry.addSvgIcon(
-      'grey-box',
-      sanitizer.bypassSecurityTrustResourceUrl('assets/GreyBox.svg'));
-  }
+  constructor(private gridService: GridService) { }
 
   ngOnInit() {
     this.gridService.getGridItems().subscribe(

--- a/templates/Web/Pages/Angular.List/src/app/app-shell/Param_SourceName_Kebab/list-item/list-item.component.ts
+++ b/templates/Web/Pages/Angular.List/src/app/app-shell/Param_SourceName_Kebab/list-item/list-item.component.ts
@@ -2,7 +2,8 @@
 
 @Component({
   selector: 'app-list-item',
-  templateUrl: './list-item.component.html'
+  templateUrl: './list-item.component.html',
+  styleUrls: ['./list-item.component.css']
 })
 export class ListItemComponent implements OnInit {
   // tslint:disable-next-line

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module.ts
@@ -1,6 +1,5 @@
 ﻿import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatIconModule } from '@angular/material/icon';
 
 import { MasterDetailComponent } from './master-detail.component';
 import { MasterDetailSidebarTabComponent } from './master-detail-sidebar-tab/master-detail-sidebar-tab.component';
@@ -17,7 +16,6 @@ import { Param_SourceName_PascalRoutingModule } from './Param_SourceName_Kebab-r
   imports: [
     CommonModule,
     WarningMessageModule,
-    MatIconModule,
     Param_SourceName_PascalRoutingModule
   ]
 })

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.css
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.css
@@ -1,0 +1,13 @@
+.title {
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.breadCrumbLink {
+  color: #025fce;
+}
+
+.heading {
+  background-color: #cecece;
+  padding-top: 18em;
+}

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.ts
@@ -4,15 +4,13 @@ import { IMasterDetailText } from '../master-detail.service';
 @Component({
   selector: 'app-master-detail-page',
   templateUrl: './master-detail-page.component.html',
-  styleUrls: ['./master-detail.component.css']
+  styleUrls: ['./master-detail-page.component.css']
 })
 export class MasterDetailPageComponent implements OnInit {
 
   @Input() textSampleData: IMasterDetailText;
   constructor() { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
 
 }
-

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-page/master-detail-page.component.ts
@@ -4,7 +4,7 @@ import { IMasterDetailText } from '../master-detail.service';
 @Component({
   selector: 'app-master-detail-page',
   templateUrl: './master-detail-page.component.html',
-  styleUrls: ['../master-detail.component.css']
+  styleUrls: ['./master-detail.component.css']
 })
 export class MasterDetailPageComponent implements OnInit {
 

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.html
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.html
@@ -1,7 +1,8 @@
 ﻿<button
-(click)="onDisplayTabClick()"
-type="button"
-class="list-group-item list-group-item-action sidebarText">
-<mat-icon svgIcon="grey-avatar" alt="Default Grey Avatar" class="mr-3"></mat-icon>
-{{tabText}}
+  (click)="onDisplayTabClick()"
+  type="button"
+  class="list-group-item list-group-item-action sidebarText"
+>
+  <img src="{{ image }}" alt="Default Grey Avatar" class="mr-3" />
+  {{ tabText }}
 </button>

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.ts
@@ -3,11 +3,12 @@
 @Component({
   selector: 'app-master-detail-sidebar-tab',
   templateUrl: './master-detail-sidebar-tab.component.html',
-  styleUrls: ['../master-detail.component.css']
+  styleUrls: ['../master-detail-sidebar-tab.component.css']
 })
 export class MasterDetailSidebarTabComponent implements OnInit {
 
   @Input() tabText: string;
+  @Input() image: string;
   @Input() index: number;
   @Input() key: number;
   @Output() displayTabClick = new EventEmitter<number>();

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail-sidebar-tab/master-detail-sidebar-tab.component.ts
@@ -3,7 +3,7 @@
 @Component({
   selector: 'app-master-detail-sidebar-tab',
   templateUrl: './master-detail-sidebar-tab.component.html',
-  styleUrls: ['../master-detail-sidebar-tab.component.css']
+  styleUrls: ['./master-detail-sidebar-tab.component.css']
 })
 export class MasterDetailSidebarTabComponent implements OnInit {
 

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.css
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.css
@@ -20,8 +20,3 @@
   background-color: #cecece;
   padding-top: 18em;
 }
-
-.mat-icon {
-  width: 40px;
-  height: 40px;
-}

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.css
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.css
@@ -2,21 +2,3 @@
   /* full height - footer height - navbar height */
   min-height: calc(100vh - 160px - 57px);
 }
-.sidebarText {
-  font-weight: 500;
-  color: #000000;
-}
-
-.title {
-  font-weight: 700;
-  margin-bottom: 0;
-}
-
-.breadCrumbLink {
-  color: #025fce;
-}
-
-.heading {
-  background-color: #cecece;
-  padding-top: 18em;
-}

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.html
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.html
@@ -7,6 +7,7 @@
           *ngFor="let textAssets of masterDetailText; let i = index"
           (displayTabClick)="handleDisplayTabClick($event)"
           [tabText]="textAssets.title"
+          [image]="GreyAvatar"
           [index]="i"
           [key]="textAssets.id"
         ></app-master-detail-sidebar-tab>

--- a/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.ts
+++ b/templates/Web/Pages/Angular.MasterDetail/src/app/app-shell/Param_SourceName_Kebab/master-detail.component.ts
@@ -1,6 +1,4 @@
 ﻿import { Component, OnInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { MatIconRegistry } from '@angular/material/icon';
 
 import { MasterDetailService, IMasterDetailText } from './master-detail.service';
 
@@ -11,16 +9,13 @@ import { MasterDetailService, IMasterDetailText } from './master-detail.service'
 })
 export class MasterDetailComponent implements OnInit {
 
+  GreyAvatar = require('../../../assets/GreyAvatar.svg') as string;
   WarningMessageText = 'Request to get master detail text failed:';
   WarningMessageOpen = false;
   currentDisplayTabIndex = 0;
   masterDetailText: IMasterDetailText[] = [];
 
-  constructor(private masterDetailService: MasterDetailService, iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {
-    iconRegistry.addSvgIcon(
-        'grey-avatar',
-        sanitizer.bypassSecurityTrustResourceUrl('assets/GreyAvatar.svg'));
-  }
+  constructor(private masterDetailService: MasterDetailService) { }
 
   ngOnInit() {
     this.masterDetailService.getMasterDetailItems().subscribe(

--- a/templates/Web/Projects/AngularDefault/.template.config/template.json
+++ b/templates/Web/Projects/AngularDefault/.template.config/template.json
@@ -62,7 +62,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'@angular/animations': '~7.2.0', '@angular/cdk': '~7.3.7', '@angular/common': '~7.2.0', '@angular/compiler': '~7.2.0', '@angular/core': '~7.2.0', '@angular/forms': '~7.2.0', '@angular/material': '^7.3.7', '@angular/platform-browser': '~7.2.0', '@angular/platform-browser-dynamic': '~7.2.0', '@angular/router': '~7.2.0', 'bootstrap': '^4.3.1', 'core-js': '^2.5.4', 'rxjs': '~6.3.3', 'tslib': '^1.9.0', 'zone.js': '~0.8.26'}",
+        "dict": "{'@angular/animations': '~7.2.0', '@angular/common': '~7.2.0', '@angular/compiler': '~7.2.0', '@angular/core': '~7.2.0', '@angular/forms': '~7.2.0','@angular/platform-browser': '~7.2.0', '@angular/platform-browser-dynamic': '~7.2.0', '@angular/router': '~7.2.0', 'bootstrap': '^4.3.1', 'core-js': '^2.5.4', 'rxjs': '~6.3.3', 'tslib': '^1.9.0', 'zone.js': '~0.8.26'}",
         "key": "dependencies",
         "jsonPath": "package.json"
       },

--- a/templates/Web/Projects/AngularDefault/src/styles.css
+++ b/templates/Web/Projects/AngularDefault/src/styles.css
@@ -1,6 +1,5 @@
 ﻿/* You can add global styles to this file, and also import other style files */
 @import '~bootstrap/dist/css/bootstrap.min.css';
-@import '~@angular/material/prebuilt-themes/indigo-pink.css';
 
 html {
   position: relative;


### PR DESCRIPTION
This is to address the "Bootstrap vs Material" in #681. We should only use of the frameworks and we decided Bootstrap, thus in this PR it reverts the Material framework of displaying svg images. 

Also in this PR it makes sure each component only utilizes its own css file. 

**How to test:**
1. generate an angular project with 4 type of pages selected
2. start the project
3. observe the grid page and master detail page, their UI should not change.
4. check each component, it should only utilize its own css file.
