### PR TITLE
step 2 angular insertion remove space and ready for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ I need a full-stack web app that stores data in a Cosmos database.
 Web Template Studio approaches web app creation using the following four attribute sets:
 
 - **Project type**: First, what type of application are you building? We currently support only one type: _Fullstack Application_.
-- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support one framework for frontend: _[React.js](https://reactjs.org/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
+- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
 - **App pages**: To accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master/detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
@@ -61,7 +61,7 @@ Please use [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues
 
 If you have specific feature requests or would like to vote on what others are recommending, please go to the [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues) section as well. We would love to see what you are thinking.
 
-We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React / Node.js golden path.
+We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React & Angular with Node.js.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ I need a full-stack web app that stores data in a Cosmos database.
 
 ## Features
 
-Web Template Studio approaches web app creation using the following four attribute sets:
+Web Template Studio approaches full-stack web app creation using the following three attribute sets:
 
-- **Project type**: First, what type of application are you building? We currently support only one type: _Fullstack Application_.
-- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
-- **App pages**: To accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master/detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
+- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
+- **App pages**: Next, to accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
 Once you make the selections you want and click generate, you can quickly extend the generated code.

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -48,6 +48,7 @@ Microsoft Web Template Studio is currently built and maintained by a new group o
 
 **Coaches**
 
+[Den Delimarsky](https://www.linkedin.com/in/dendeli/),
 [Juan Camilo Osorio](https://www.linkedin.com/in/jcoc611/),
 [Meha Kaushik](https://www.linkedin.com/in/meha-kaushik-22931210a/),
 [Piotr Markowski](https://www.linkedin.com/in/piotr-markowski-7728b09a/)

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -1,6 +1,6 @@
 # Acknowledgments
 
-Microsoft Web Template Studio was initially built by a great group of interns from the Microsoft Garage.  This full list of individuals that helped build the project during the first quarter of 2019.
+Microsoft Web Template Studio was initially built by a great group of interns from the Microsoft Garage. This full list of individuals that helped build the project during the first quarter of 2019.
 
 **Design Intern**
 
@@ -26,6 +26,31 @@ Microsoft Web Template Studio was initially built by a great group of interns fr
 [Mark Schramm](https://www.linkedin.com/in/markschramm/),
 [Mohannad Abwah](https://www.linkedin.com/in/mohannad-abwah-1156944a/),
 [Tejbir Sodhan](https://www.linkedin.com/in/tejbirsodhan/)
+
+**Program Managers**
+
+[Clint Rutkas](https://www.linkedin.com/in/clintrutkas/),
+[Stephane Morichere-Matte](https://www.linkedin.com/in/stephanemoricherematte/)
+
+Microsoft Web Template Studio is currently built and maintained by a new group of interns from the Microsoft Garage. This full list of individuals that helped build the project during the summer quarter of 2019.
+
+**Design Intern**
+
+[Christina Weng](https://www.linkedin.com/in/christina-weng/)
+
+**Developer Interns**
+
+[Annie Liang](https://www.linkedin.com/in/annie-l-715643a1/),
+[Nipun Jindal](https://www.linkedin.com/in/nipun-jindal-87046510a/),
+[Jasmin Goh](https://www.linkedin.com/in/jasmingoh/),
+[JeongSoo (Jason) Doo](https://www.linkedin.com/in/jason-doo/),
+[Tanya Tan](https://www.linkedin.com/in/tanya-tan-programmer/)
+
+**Coaches**
+
+[Juan Camilo Osorio](https://www.linkedin.com/in/jcoc611/),
+[Meha Kaushik](https://www.linkedin.com/in/meha-kaushik-22931210a/),
+[Piotr Markowski](https://www.linkedin.com/in/piotr-markowski-7728b09a/)
 
 **Program Managers**
 

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -43,7 +43,7 @@ Microsoft Web Template Studio is currently built and maintained by a new group o
 [Annie Liang](https://www.linkedin.com/in/annie-l-715643a1/),
 [Nipun Jindal](https://www.linkedin.com/in/nipun-jindal-87046510a/),
 [Jasmin Goh](https://www.linkedin.com/in/jasmingoh/),
-[JeongSoo (Jason) Doo](https://www.linkedin.com/in/jason-doo/),
+[Jason Doo](https://www.linkedin.com/in/jason-doo/),
 [Tanya Tan](https://www.linkedin.com/in/tanya-tan-programmer/)
 
 **Coaches**
@@ -56,3 +56,8 @@ Microsoft Web Template Studio is currently built and maintained by a new group o
 
 [Clint Rutkas](https://www.linkedin.com/in/clintrutkas/),
 [Stephane Morichere-Matte](https://www.linkedin.com/in/stephanemoricherematte/)
+
+**Sponsors**
+
+[Michael Harsh](https://www.linkedin.com/in/michael-harsh/),
+[Sibille Metzler](https://www.linkedin.com/in/sibille-metzler-823609/)

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -18,7 +18,7 @@ Docs to provide useful insights.
 Web Template Studio approaches web app creation using the following four attribute sets:
 
 - **Project type**: First, what type of application are you building? We currently support only one type: _Fullstack Application_.
-- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support one framework for frontend: _[React.js](https://reactjs.org/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
+- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
 - **App pages**: To accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
@@ -30,7 +30,7 @@ Please use [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues
 
 If you have specific feature requests or would like to vote on what others are recommending, please go to the [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues) section as well. We would love to hear your thoughts.
 
-We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React / Node.js golden path.
+We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React & Angular with Node.js.
 
 ## Contributing
 

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -15,11 +15,10 @@ Docs to provide useful insights.
 
 ## Features
 
-Web Template Studio approaches web app creation using the following four attribute sets:
+Web Template Studio approaches full-stack web app creation using the following three attribute sets:
 
-- **Project type**: First, what type of application are you building? We currently support only one type: _Fullstack Application_.
-- **Frameworks**: Next, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
-- **App pages**: To accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
+- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and one framework for backend: _[Node.js](https://nodejs.org/en/)_.
+- **App pages**: Next, to accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
 Once you make the selections you want and click generate, you can quickly extend the generated code.

--- a/templates/Web/_composition/AngularJS/Page.Angular.AddImport/src/app/app.module_postaction.ts
+++ b/templates/Web/_composition/AngularJS/Page.Angular.AddImport/src/app/app.module_postaction.ts
@@ -4,11 +4,11 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+//{[{
+import { Param_SourceName_PascalModule } from './app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module';
+//}]}
 import { NavBarComponent } from './app-shell/nav-bar/nav-bar.component';
 import { FooterComponent } from './app-shell/footer/footer.component';
-//{[{
-import {Param_SourceName_PascalModule} from './app-shell/Param_SourceName_Kebab/Param_SourceName_Kebab.module';
-//}]}
 
 @NgModule({
   declarations: [

--- a/templates/_catalog/frontendframeworks.json
+++ b/templates/_catalog/frontendframeworks.json
@@ -24,7 +24,7 @@
     "languages": ["Any"],
     "tags": {
       "version": "7.2.0",
-      "preview": true
+      "preview": false
     }
   },
   {


### PR DESCRIPTION
This PR is to update the GitHub main page, acknowledgement page and the page in the marketplace to include Angular as a frontend framework. Also, this PR move Angular out of preview mode.

How to test:

1. (make sure you close your preview mode in vs code extensions)
2. start extension, you should be able to see Angular is one of the frontend frameworks option
3. check all three .MD files has no spelling mistakes, names are sorted in alphabetic order (on first name), links are working
4. generate an angular project with 4 pages selected. In app.module.ts, you should see 
**expected:**
<img width="763" alt="no-additional-space" src="https://user-images.githubusercontent.com/12874317/59932176-7b868a80-93fb-11e9-842e-3ae1f8a5ac87.png">
**before change**
<img width="686" alt="space" src="https://user-images.githubusercontent.com/12874317/59932178-7d504e00-93fb-11e9-9735-bb5b0957c8da.png">
