### PR TITLE
change constant file name

### DIFF
--- a/src/extension/src/coreTemplateStudio.ts
+++ b/src/extension/src/coreTemplateStudio.ts
@@ -7,7 +7,7 @@ import * as os from "os";
 import * as fs from "fs";
 
 import { ChildProcess, execFile } from "child_process";
-import { CONSTANTS } from "./CONSTANTS";
+import { CONSTANTS } from "./constants";
 import { GenerateCommand } from "./signalr-api-module/generateCommand";
 import { SyncCommand } from "./signalr-api-module/syncCommand";
 import { ICommandPayload } from "./signalr-api-module/commandPayload";


### PR DESCRIPTION
Thanks to @sibille  for catching this; the extension was not launching on Linux. 

Check:
Extension should be able to run on Linux now.
