### PR TITLE
angular hot fix for typo in angular framework card

### DIFF
--- a/templates/_catalog/frontendframeworks.json
+++ b/templates/_catalog/frontendframeworks.json
@@ -16,7 +16,7 @@
   {
     "name": "Angular",
     "displayName": "Angular",
-    "summary": "Angular is an open source, front-end web application framework mainly mainted by Google to develop single page applications.",
+    "summary": "Angular is an open source, front-end web application framework maintained by Google to develop single page applications.",
     "author": "Google",
     "order": "1",
     "licenses": "[Angular](https://github.com/angular/angular/blob/master/LICENSE)  \n[Angular CLI](https://github.com/angular/angular-cli/blob/master/LICENSE)",


### PR DESCRIPTION
fix typo "matined" into "maintained", also removed word "mainly"

![angular-icon](https://user-images.githubusercontent.com/12874317/60059715-80b93300-96a2-11e9-84dd-e576fc1381dc.PNG)
