### PR TITLE
Get Flask out of preview mode - Release Ready

### DIFF
--- a/templates/_catalog/backendframeworks.json
+++ b/templates/_catalog/backendframeworks.json
@@ -24,7 +24,7 @@
     "languages": ["Any"],
     "tags": {
       "version": "Python: 3.7.3, Flask: 1.0.3",
-      "preview": true
+      "preview": false
     }
   }
 ]


### PR DESCRIPTION
Task: https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/30044

**Expected outcome**
- Turn off the preview mode and launch the Extension. Flask should be available as a backend framework to be used in the application.

closes #810 