### PR TITLE
Changed casing for the coreTSModule import statement

### DIFF
--- a/src/extension/src/controller.ts
+++ b/src/extension/src/controller.ts
@@ -17,7 +17,7 @@ import { GenerationExperience } from "./generationExperience";
 import { IVSCodeProgressType } from "./types/vscodeProgressType";
 import { LaunchExperience } from "./launchExperience";
 import { DependencyChecker } from "./utils/dependencyChecker";
-import { CoreTSModule } from "./CoreTSModule";
+import { CoreTSModule } from "./coreTSModule";
 
 export class Controller {
   /**


### PR DESCRIPTION
This is done so that extension can be launched on Linux OS