### PR TITLE
disable top-nav on modal open

### DIFF
--- a/src/client/src/components/Modal/index.tsx
+++ b/src/client/src/components/Modal/index.tsx
@@ -37,6 +37,7 @@ const getCustomStyles = (MODAL_TYPE: ModalType | undefined) => {
       left: 0,
       right: 0,
       bottom: 0,
+      zIndex: 2000,
       backgroundColor: "rgba(0, 0, 0, 0.6)"
     },
     content: {


### PR DESCRIPTION
closes #899 
How to test/changes:
- when you open a modal component, you cannot use the top nav bar until you exit 