### PR TITLE
color works in light mode for view licenses and post generation modals

### DIFF
--- a/src/client/src/containers/Licenses/styles.module.css
+++ b/src/client/src/containers/Licenses/styles.module.css
@@ -4,7 +4,7 @@
   font-weight: 300;
   margin-bottom: 6px;
   font-size: 24px;
-  color: #ffffff;
+  color: var(--vscode-editor-foreground);
 }
 
 .container {

--- a/src/client/src/containers/PostGenerationModal/styles.module.css
+++ b/src/client/src/containers/PostGenerationModal/styles.module.css
@@ -3,14 +3,14 @@
   font-size: 21px;
   font-weight: lighter;
   line-height: 19px;
-  color: #ffffff;
+  color: var(--vscode-editor-foreground);
 }
 .title {
   font-size: 21px;
   font-family: "Segoe UI";
   font-weight: lighter;
   line-height: 25px;
-  color: #ffffff;
+  color: var(--vscode-editor-foreground);
 }
 
 .section {


### PR DESCRIPTION
**How to Test:**
1. start the extension in my branch
2. when you are in vscode extension, do "ctrl+k", and "ctrl+t" and select light theme
3. click view licenses when you can, everything in the modal should be visible
4. click create project, everything in the post generation modal should be visible 

**Expected:**
![post-gen-modal](https://user-images.githubusercontent.com/12874317/61474659-f29d3900-a93d-11e9-8792-6f5615410738.PNG)
![licenses-light](https://user-images.githubusercontent.com/12874317/61475140-0006f300-a93f-11e9-80bc-38ec73fc60e8.PNG)
