### PR TITLE
Updating all references of Project Acorn to Web Template Studio

### DIFF
--- a/src/client/public/index.html
+++ b/src/client/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Project Acorn</title>
+    <title>Web Template Studio</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/client/src/selectors/appServiceSelector.ts
+++ b/src/client/src/selectors/appServiceSelector.ts
@@ -20,7 +20,7 @@ export interface ISelectionInformation {
  * Returns the App Service selection made by the user
  * Returns undefined if a selection was not made.
  *
- * @param services An object of all the services available in Project Acorn
+ * @param services An object of all the services available in Web Template Studio
  */
 const getAppServiceSelectionInDropdownForm = (
   appState: AppState

--- a/src/client/src/selectors/cosmosServiceSelector.ts
+++ b/src/client/src/selectors/cosmosServiceSelector.ts
@@ -41,7 +41,7 @@ const getCosmosDbSelectionSelector = createSelector(
  * Currently, only one Cosmos Resource can be added, hence
  * the hardcoded value of 0 index.
  *
- * @param services An object of all the services available in Project Acorn
+ * @param services An object of all the services available in Web Template Studio
  */
 const getCosmosSelectionInDropdownForm = (services: any): any => {
   const { selection } = services.selection.services.cosmosDB;

--- a/templates/Web/_composition/NodeJS/Feature.Node.Azure.Cosmos.SQL/server/sql/sqlController.js
+++ b/templates/Web/_composition/NodeJS/Feature.Node.Azure.Cosmos.SQL/server/sql/sqlController.js
@@ -31,7 +31,7 @@ module.exports = class SQLController {
 
   // Post a new item to the ListItem container in Cosmos Core SQL List database
   async create(req, res, next) {
-    // TODO Project Acorn: The Cosmos Core SQL Database is set up to hold a container called ListItems which contains documents
+    // TODO Web Template Studio: The Cosmos Core SQL Database is set up to hold a container called ListItems which contains documents
     // with the following schema. Define your own schema to add documents to the container here.
     var listItem = {
       text: req.body.text


### PR DESCRIPTION
When I ran the client I noticed the html title was still Project Acorn. These are last references to Project Acorn that I could find.

Changes:
- Updating all references of _Project Acorn_ to be **Web Template Studio**

How to test:
- Run the client application and view the browser tab title: 
![image](https://user-images.githubusercontent.com/2815284/61662388-3025fd00-ac83-11e9-98d7-233581b69511.png)

