### PR TITLE
Display progress on generation modal

### DIFF
--- a/src/client/src/containers/PostGenerationModal/index.tsx
+++ b/src/client/src/containers/PostGenerationModal/index.tsx
@@ -162,6 +162,8 @@ const PostGenerationModal = ({
       }
     });
   };
+  const templateGenerationInProgress =
+    !isTemplateGenerated && !isTemplatesFailed;
   return (
     <div>
       <div className={styles.title}>
@@ -230,8 +232,12 @@ const PostGenerationModal = ({
       </div>
       <div className={styles.footerContainer}>
         <button
-          className={classnames(buttonStyles.buttonHighlighted, styles.button)}
+          className={classnames(styles.button, {
+            [buttonStyles.buttonDark]: templateGenerationInProgress,
+            [buttonStyles.buttonHighlighted]: !templateGenerationInProgress
+          })}
           onClick={handleOpenProjectOrRestartWizard}
+          disabled={templateGenerationInProgress}
         >
           {openProjectOrRestartWizardMessage()}
         </button>

--- a/src/extension/src/signalr-api-module/generateCommand.ts
+++ b/src/extension/src/signalr-api-module/generateCommand.ts
@@ -17,7 +17,8 @@ export class GenerateCommand extends CoreTemplateStudioApiCommand {
 
     connection.on(CONSTANTS.API.GEN_LIVE_MESSAGE_TRIGGER_NAME, genMessage => {
       generatedItemsCount++;
-      const messageWithProgress = `(${generatedItemsCount}/${itemsToGenerateCount}) ${genMessage}`;
+      const percentage = (generatedItemsCount / itemsToGenerateCount) * 100;
+      const messageWithProgress = `(${percentage.toFixed(0)} %) ${genMessage}`;
       this.commandPayload.liveMessageHandler(messageWithProgress);
     });
 

--- a/src/extension/src/signalr-api-module/generateCommand.ts
+++ b/src/extension/src/signalr-api-module/generateCommand.ts
@@ -18,7 +18,7 @@ export class GenerateCommand extends CoreTemplateStudioApiCommand {
     connection.on(CONSTANTS.API.GEN_LIVE_MESSAGE_TRIGGER_NAME, genMessage => {
       generatedItemsCount++;
       const percentage = (generatedItemsCount / itemsToGenerateCount) * 100;
-      const messageWithProgress = `(${percentage.toFixed(0)} %) ${genMessage}`;
+      const messageWithProgress = `(${percentage.toFixed(0)}%) ${genMessage}`;
       this.commandPayload.liveMessageHandler(messageWithProgress);
     });
 

--- a/src/extension/src/signalr-api-module/generateCommand.ts
+++ b/src/extension/src/signalr-api-module/generateCommand.ts
@@ -5,14 +5,21 @@ import { IEngineGenerationPayloadType } from "../types/engineGenerationPayloadTy
 
 export class GenerateCommand extends CoreTemplateStudioApiCommand {
   async performCommandAction(connection: signalR.HubConnection): Promise<any> {
-    let body = this.makeEngineGenerationPayload(<IGenerationPayloadType>(
-      this.commandPayload.payload
-    ));
+    const payload = <IGenerationPayloadType>this.commandPayload.payload;
+    const body = this.makeEngineGenerationPayload(payload);
 
-    connection.on(
-      CONSTANTS.API.GEN_LIVE_MESSAGE_TRIGGER_NAME,
-      this.commandPayload.liveMessageHandler
-    );
+    const projectItemsToGenerateCount = 4; // Derived from CoreTS logic
+    const itemsToGenerateCount =
+      projectItemsToGenerateCount +
+      payload.pages.length +
+      payload.services.length;
+    let generatedItemsCount = 0;
+
+    connection.on(CONSTANTS.API.GEN_LIVE_MESSAGE_TRIGGER_NAME, genMessage => {
+      generatedItemsCount++;
+      const messageWithProgress = `(${generatedItemsCount}/${itemsToGenerateCount}) ${genMessage}`;
+      this.commandPayload.liveMessageHandler(messageWithProgress);
+    });
 
     const result = await connection
       .invoke(CONSTANTS.API.SIGNALR_API_GENERATE_METHOD_NAME, body)


### PR DESCRIPTION
Changes:
- Disable the button when generation in progress
- Display generation progress.

The generation status message is being passed from coreTS to the extension and then from the extension to the client. Both extension and client just listen to the message and pass it, the message itself is generated in coreTS. Because of that there were 3 ways to do it:
1. Hack the progress on the client side (super hacky)
2. Hack the progress on the extension side and pass in the message to the client (less hacky, but not ideal)
3. Generate progress info in CoreTS and pass it to the extension (best way IMO)

Now, I choose option 2, because it's hackiness is acceptable IMO and option 3 would require changing the CoreTS API contract and probably coordination with WinTS. Instead I intercept the message in the extension and concatenate the progress info based on the Generate message payload.

Take a look and decide whether you want to merge this version or do it properly in CoreTS :)

How to test:
- Generate project with pages and/or Azure services
- Generation modal should look like this:

![image](https://user-images.githubusercontent.com/9086862/61664325-69f90280-ac87-11e9-8464-aae6a1d0f763.png)
