### PR TITLE
List page icon was missing in local dev

### DIFF
--- a/src/client/src/mockData/mockVsCodeApi.ts
+++ b/src/client/src/mockData/mockVsCodeApi.ts
@@ -272,7 +272,7 @@ const mockVsCodeApi = () => ({
                     requiredVisualStudioWorkloads: []
                   },
                   {
-                    emplateId: "wts.Page.React.List",
+                    templateId: "wts.Page.React.List",
                     name: "List",
                     defaultName: "List",
                     description: "Add and remove text from an adaptive list.",


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2815284/61755938-9a679c00-ad6e-11e9-803c-944038c4edaf.png)

After:
![image](https://user-images.githubusercontent.com/2815284/61755940-a18eaa00-ad6e-11e9-889a-fca50734a952.png)

This closes #922 