### PR TITLE
Making the Working button not look like an active button

### DIFF
--- a/src/client/src/containers/PostGenerationModal/index.tsx
+++ b/src/client/src/containers/PostGenerationModal/index.tsx
@@ -230,7 +230,12 @@ const PostGenerationModal = ({
       </div>
       <div className={styles.footerContainer}>
         <button
-          className={classnames(buttonStyles.buttonHighlighted, styles.button)}
+          className={classnames(
+            styles.button,
+            isTemplatesFailed || isTemplateGenerated
+              ? buttonStyles.buttonHighlighted
+              : classnames(styles.buttonInactive, buttonStyles.buttonDark)
+          )}
           onClick={handleOpenProjectOrRestartWizard}
         >
           {openProjectOrRestartWizardMessage()}

--- a/src/client/src/containers/PostGenerationModal/styles.module.css
+++ b/src/client/src/containers/PostGenerationModal/styles.module.css
@@ -44,6 +44,10 @@
   padding: 10px 33px;
 }
 
+.buttonInactive {
+  cursor: default !important;
+}
+
 .button:focus {
   outline: 1px solid var(--vscode-contrastActiveBorder);
 }


### PR DESCRIPTION
#897 
When the post-generation modal was working on generating the project, the Working button looked like an active button. I updated the styling to follow @SahilTara suggestion and make it a dark inactive button. If the Template is not failed or generated then it will have dark button styling.

Before:
![image](https://user-images.githubusercontent.com/2815284/61756824-bff6a480-ad72-11e9-9b3a-198210fe1e4e.png)

After:
![image](https://user-images.githubusercontent.com/2815284/61756896-19f76a00-ad73-11e9-870e-fd60f407a05e.png)

