### PR TITLE
AppService and AzureFunctions modal were not correctly setting inputs as 'disabled'

### DIFF
--- a/src/client/src/containers/AppServiceModal/index.tsx
+++ b/src/client/src/containers/AppServiceModal/index.tsx
@@ -527,7 +527,7 @@ const AppServiceModal = (props: Props) => {
                 onChange={handleInput}
                 value={appServiceFormData.siteName.value}
                 placeholder={FORM_CONSTANTS.SITE_NAME.label}
-                disabled={appServiceFormData.subscription === ""}
+                disabled={appServiceFormData.subscription.value === ""}
                 tabIndex={appServiceFormData.subscription.value === "" ? -1 : 0}
               />
               {isSiteNameAvailable && !isValidatingName && (

--- a/src/client/src/containers/AzureFunctionsModal/index.tsx
+++ b/src/client/src/containers/AzureFunctionsModal/index.tsx
@@ -545,7 +545,7 @@ const AzureFunctionsResourceModal = (props: Props) => {
                 onChange={handleInput}
                 value={azureFunctionsFormData.appName.value}
                 placeholder={FORM_CONSTANTS.APP_NAME.label}
-                disabled={azureFunctionsFormData.subscription === ""}
+                disabled={azureFunctionsFormData.subscription.value === ""}
                 tabIndex={
                   azureFunctionsFormData.subscription.value === "" ? -1 : 0
                 }


### PR DESCRIPTION
The comparison used to be an object to string match. This fixed #947 

Before:
![image](https://user-images.githubusercontent.com/2815284/61898587-7d49df00-aece-11e9-9122-0225c0ad4b04.png)

After:
![image](https://user-images.githubusercontent.com/2815284/61898603-86d34700-aece-11e9-9fbe-f012ac6fd332.png)

