### PR TITLE
Update cli path in vscodeignore to build extension correctly

### DIFF
--- a/src/extension/.vscodeignore
+++ b/src/extension/.vscodeignore
@@ -8,7 +8,7 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
-!src/api/**
+!src/corets-cli/**
 !src/azure/azure-cosmosDB/arm-templates
 !src/azure/azure-functions/arm-templates
 !src/azure/azure-functions/templates


### PR DESCRIPTION
When we compile the extension to generate the vsix, the src/corets-cli folder is not added, since it is not used directly in the code and is discarded. We modify the corets-cli path in gitignore file so that the compilation add this folder.