### PR TITLE
hot fix for template tests

### DIFF
--- a/src/extension/src/coreTemplateStudio.ts
+++ b/src/extension/src/coreTemplateStudio.ts
@@ -105,9 +105,9 @@ export class CoreTemplateStudio {
     });
 
     process.stderr.on("data", (data) => {
-      this.cliEvents.emit("error", data.toString());
+      this.cliEvents.emit("eventError", data.toString());
     });
-    process.on("exit", (code) => this.cliEvents.emit("error", `process exited with code ${code}`));
+    process.on("exit", (code) => this.cliEvents.emit("eventError", `process exited with code ${code}`));
   }
 
   private async awaitCliEvent(eventName: string): Promise<any> {
@@ -115,7 +115,7 @@ export class CoreTemplateStudio {
       this.cliEvents.once(eventName, (data) => {
         this.cliEvents.removeAllListeners();
         resolve(data);
-      }).once("error", (data) => {
+      }).once("eventError", (data) => {
         this.cliEvents.removeAllListeners();
         reject(data);
       });

--- a/src/extension/src/scripts/generate-test.ts
+++ b/src/extension/src/scripts/generate-test.ts
@@ -9,7 +9,7 @@ let syncAttemptNum = 0;
 let prevPromise: Promise<any> = Promise.resolve(null);
 
 const delay = (time: number) => {
-  return new Promise(function (resolve) {
+  return new Promise((resolve) => {
     setTimeout(resolve, time);
   });
 };

--- a/src/extension/src/scripts/run-tests.ts
+++ b/src/extension/src/scripts/run-tests.ts
@@ -13,11 +13,11 @@ fs.readdirSync(testFolder).forEach((file: string) => {
 
 function kill(pid: any) {
   try {
-    child_process.execSync("taskkill /PID " + pid + " /T /F", function(
+    child_process.execSync("taskkill /PID " + pid + " /T /F", (
       error: any,
       stdout: any,
       stderr: any
-    ) {
+    ) => {
       console.log("Stdout from kill: " + stdout);
       console.log("Stderr from kill:" + stderr);
       if (error !== null) {
@@ -74,7 +74,7 @@ asyncForEach(files, async (file: string) => {
         console.log(`Stdout from yarn start: ${stdout}`);
       }
     );
-    serverProcess.stdout.on("data", function(data: any) {
+    serverProcess.stdout.on("data", (data: any) => {
       console.log(data);
       if (data.toString().indexOf("Traceback") > -1) {
         throw new Error("Error found in project");
@@ -107,7 +107,7 @@ asyncForEach(files, async (file: string) => {
         console.log(`Stdout from yarn test: ${stdout}`);
       }
     );
-    testProcess.stdout.on("data", function(data: any) {
+    testProcess.stdout.on("data", (data: any) => {
       console.log(data);
       if (data.toString().indexOf("FAILED") > -1) {
         throw new Error("Error: Test failed");


### PR DESCRIPTION
The reason the template tests failing was an unhandled error. This error supposed to be handled by an event in the coreTS script, but due to the event has the same name as some default name. The event doesn't work.  Thus this PR changed the event name to some new name and it solved the problem.

Also, fix two places based on tslint's suggestion in the test scripts.

**How to test:**
1. _cd src/extension_
2. run _yarn template-tests_, the tests should pass rather than throw an error