### PR TITLE
App Service - have timestamp in generated ASP name

### DIFF
--- a/src/extension/src/azure/azure-app-service/appServiceProvider.ts
+++ b/src/extension/src/azure/azure-app-service/appServiceProvider.ts
@@ -234,7 +234,7 @@ export class AppServiceProvider {
   }
 
   public async generateValidASPName(name: string): Promise<string> {
-    let generatedName: string = name + "-asp";
+    let generatedName: string = NameGenerator.generateName(name, "asp");
     let isValid: boolean = await this.validateASPName(generatedName);
     let tries = 0;
     while (tries < CONSTANTS.VALIDATION_LIMIT && !isValid) {


### PR DESCRIPTION
This PR addresses the consistency for the generated names.

Currently, for App Service Plan (ASP), if <project name> is a valid ASP name, we would just create an ASP with that name.

But as @jsondoo suggested, it would be good for all generate name to be consistent, i.e. <project name>_<resource type?>_<timestamp>.

To test,
- Launch the extension in preview mode 
- Take note of the project name
- Add App Service in the Azure page (do "Create a new resource group")
- Create the project
- Go to Azure portal and search for the resource group (it should start with your project name)
- Make sure that the name of the ASP created has a timestamp, i.e. <project name>_asp_<timestamp>