### PR TITLE
Disable 'Create Project' on Invalid Project Name or Location

### DIFF
--- a/src/client/src/containers/Footer/index.tsx
+++ b/src/client/src/containers/Footer/index.tsx
@@ -280,11 +280,12 @@ class Footer extends React.Component<Props> {
               )}
               {enableCreateProjectButton && (
                 <button
-                  disabled={!areValidNames}
+                  disabled={!areValidNames || !isValidNameAndProjectPath}
                   className={classnames(styles.button, {
                     [buttonStyles.buttonDark]: !areValidNames,
                     [buttonStyles.buttonHighlightedBorder]: areValidNames,
-                    [styles.disabledOverlay]: !areValidNames
+                    [styles.disabledOverlay]:
+                      !areValidNames || !isValidNameAndProjectPath
                   })}
                   onClick={this.logMessageToVsCode}
                 >


### PR DESCRIPTION
Task: https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/32563

**Changes**
- Add project name and output path validation on disable check for 'Create Project' Button

**How To Test**
- Create a project with some name, say 'MyApp'
- Now, try to create another project with some name 'MyApp1'
- Before actually creating the project, go back to the Home Page, and change project name to 'MyApp'.
- 'Create Project' Button should be disabled.

closes #1057 