### PR TITLE
Azure names - Zero-padded timestamp

### DIFF
--- a/src/extension/src/azure/utils/nameGenerator.ts
+++ b/src/extension/src/azure/utils/nameGenerator.ts
@@ -61,9 +61,6 @@ export namespace NameGenerator {
   }
 
   function padStart(x: number): string {
-    if (x < 10) {
-      return "0" + x.toString();
-    }
-    return x.toString();
+    return x.toString().padStart(2, "0");
   }
 }

--- a/src/extension/src/azure/utils/nameGenerator.ts
+++ b/src/extension/src/azure/utils/nameGenerator.ts
@@ -62,7 +62,7 @@ export namespace NameGenerator {
 
   function padStart(x: number): string {
     if (x < 10) {
-      return 0 + x.toString();
+      return "0" + x.toString();
     }
     return x.toString();
   }

--- a/src/extension/src/azure/utils/nameGenerator.ts
+++ b/src/extension/src/azure/utils/nameGenerator.ts
@@ -52,11 +52,18 @@ export namespace NameGenerator {
     const fullDate = new Date(unixTimestamp);
     const year = fullDate.getFullYear().toString();
     // getMonth() returns month as a zero-based value
-    const month = (fullDate.getMonth() + 1).toString();
-    const date = fullDate.getDate().toString();
-    const hour = fullDate.getHours().toString();
-    const min = fullDate.getMinutes().toString();
-    const sec = fullDate.getSeconds().toString();
+    const month = padStart(fullDate.getMonth() + 1);
+    const date = padStart(fullDate.getDate());
+    const hour = padStart(fullDate.getHours());
+    const min = padStart(fullDate.getMinutes());
+    const sec = padStart(fullDate.getSeconds());
     return year.concat(month, date, hour, min, sec);
+  }
+
+  function padStart(x: number): string {
+    if (x < 10) {
+      return 0 + x.toString();
+    }
+    return x.toString();
   }
 }

--- a/src/extension/tsconfig.json
+++ b/src/extension/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6", "dom"],
+    "lib": ["es2017", "dom"],
     "sourceMap": true,
     "rootDir": "src",
     /* Strict Type-Checking Option */


### PR DESCRIPTION
This is required for generating consistent timestamps, i.e. yyyymmddhhmmss

The single digit component should be padded with 0.

**To test:**
1. Launch the extension in preview mode
2. Go to the Azure page
3. Add any Azure service to open up the forms
4. Select a subscription
5. Make sure tha the timestamp of the generated name follows the format above (yyyymmddhhmmss).