### PR TITLE
VueJS: Preview no more!

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ I need a full-stack web app that stores data in a Cosmos database.
 
 Web Template Studio approaches full-stack web app creation using the following three attribute sets:
 
-- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and two frameworks for backend: _[Node.js](https://nodejs.org/en/)_, _[Flask](http://flask.pocoo.org/)_. We also provide a dependency checker to make sure you have the required version of Node and/or Python installed.
+- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support three frameworks for frontend: _[React](https://reactjs.org/)_, _[Angular](https://angular.io/)_, _[Vue.js](https://vuejs.org/)_ and two frameworks for backend: _[Node](https://nodejs.org/en/)_, _[Flask](http://flask.pocoo.org/)_. We also provide a dependency checker to make sure you have the required version of Node and/or Python installed.
 - **App pages**: Next, to accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
@@ -60,7 +60,7 @@ Please use [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues
 
 If you have specific feature requests or would like to vote on what others are recommending, please go to the [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues) section as well. We would love to see what you are thinking.
 
-We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React & Angular with Node.js.
+We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React, Angular and Vue.js with Node and Flask.
 
 ## Contributing
 

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -44,7 +44,12 @@ Microsoft Web Template Studio is currently built and maintained by a new group o
 [Nipun Jindal](https://www.linkedin.com/in/nipun-jindal-87046510a/),
 [Jasmin Goh](https://www.linkedin.com/in/jasmingoh/),
 [Jason Doo](https://www.linkedin.com/in/jason-doo/),
-[Tanya Tan](https://www.linkedin.com/in/tanya-tan-programmer/)
+[Tanya Tan](https://www.linkedin.com/in/tanya-tan-programmer/),
+[Ali Khamesy](https://www.linkedin.com/in/ali-khamesy-038003158/)
+
+**Program Manager Intern**  
+
+[Lea Akkari](https://www.linkedin.com/in/lea-akkari-640889103/)
 
 **Coaches**
 

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -17,7 +17,7 @@ Docs to provide useful insights.
 
 Web Template Studio approaches full-stack web app creation using the following three attribute sets:
 
-- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support two frameworks for frontend: _[React.js](https://reactjs.org/)_, _[Angular](https://angular.io/)_ and two frameworks for backend: _[Node.js](https://nodejs.org/en/)_, _[Flask](http://flask.pocoo.org/)_. We also provide a dependency checker to make sure you have the required version of Node and/or Python installed.
+- **Frameworks**: First, which frameworks do you want to use for your frontend and backend? We currently support three frameworks for frontend: _[React](https://reactjs.org/)_, _[Angular](https://angular.io/)_, _[Vue.js](https://vuejs.org/)_ and two frameworks for backend: _[Node](https://nodejs.org/en/)_, _[Flask](http://flask.pocoo.org/)_. We also provide a dependency checker to make sure you have the required version of Node and/or Python installed.
 - **App pages**: Next, to accelerate app creation, we provide a number of app page templates that you can use to add common UI pages into your new app. The current page templates include: _blank page_, common layouts (*e.g., master detail) and pages that implement common patterns (*e.g., grid, list). Using the wizard, add as many of the pages as you need, providing a name for each one, and we'll generate them for you.
 - **Cloud Services**: Lastly, you specify which Azure cloud services you want to use, and we'll build out the framework for the services into your app including tagging 'TODO' items. Currently supported services cover storage (_Azure Cosmos DB_), and compute (_Azure Functions_).
 
@@ -29,7 +29,7 @@ Please use [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues
 
 If you have specific feature requests or would like to vote on what others are recommending, please go to the [GitHub issues](https://github.com/Microsoft/WebTemplateStudio/issues) section as well. We would love to hear your thoughts.
 
-We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React & Angular with Node.js.
+We are still extremely early in development and are looking for feedback for roadmap. Currently we are in the process of stabilizing our React, Angular and Vue.js with Node and Flask.
 
 ## Contributing
 

--- a/templates/_catalog/frontendframeworks.json
+++ b/templates/_catalog/frontendframeworks.json
@@ -6,8 +6,12 @@
     "author": "Facebook",
     "order": "1",
     "licenses": "[React](https://github.com/facebook/react/blob/master/LICENSE)  \n[Create React App](https://github.com/facebook/create-react-app/blob/master/LICENSE)",
-    "platforms": ["Web"],
-    "languages": ["Any"],
+    "platforms": [
+      "Web"
+    ],
+    "languages": [
+      "Any"
+    ],
     "tags": {
       "version": "16.8.4",
       "preview": false
@@ -20,8 +24,12 @@
     "author": "Google",
     "order": "1",
     "licenses": "[Angular](https://github.com/angular/angular/blob/master/LICENSE)  \n[Angular CLI](https://github.com/angular/angular-cli/blob/master/LICENSE)",
-    "platforms": ["Web"],
-    "languages": ["Any"],
+    "platforms": [
+      "Web"
+    ],
+    "languages": [
+      "Any"
+    ],
     "tags": {
       "version": "8.0.2",
       "preview": false
@@ -34,11 +42,15 @@
     "author": "Evan You",
     "order": "1",
     "licenses": "[Vue](https://github.com/vuejs/vue/blob/dev/LICENSE)  \n[Vue CLI](https://github.com/vuejs/vue-cli/blob/dev/LICENSE)",
-    "platforms": ["Web"],
-    "languages": ["Any"],
+    "platforms": [
+      "Web"
+    ],
+    "languages": [
+      "Any"
+    ],
     "tags": {
       "version": "2.6.6",
-      "preview": true
+      "preview": false
     }
   }
 ]


### PR DESCRIPTION
Updated READMES, and disabled Vue's preview flag. 

Check for grammar and spelling mistakes. 
Build and Launch without preview mode, should see Vue as a selectable framework.