### PR TITLE
Add build scripts for all front-end frameworks

### DIFF
--- a/templates/Web/Projects/AngularDefault/.template.config/template.json
+++ b/templates/Web/Projects/AngularDefault/.template.config/template.json
@@ -62,7 +62,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'@angular/animations': '~8.0.2', '@angular/cli': '~7.3.5', '@angular/common': '~8.0.2', '@angular/compiler': '~8.0.2', '@angular/compiler-cli': '~8.0.2', '@angular/core': '~8.0.2', '@angular/forms': '~8.0.2','@angular/platform-browser': '~8.0.2', '@angular/platform-browser-dynamic': '~8.0.2', '@angular/router': '~8.0.2', '@angular-devkit/build-angular': '~0.13.0', '@ng-bootstrap/ng-bootstrap': '^4.2.1', '@types/node': '~8.9.4', 'bootstrap': '^4.3.1', 'core-js': '^2.5.4', 'rxjs': '~6.5.2', 'tslib': '^1.9.0', 'typescript': '~3.4.5', 'zone.js': '~0.9.1'}",
+        "dict": "{'@angular/animations': '~8.0.2', '@angular/cli': '~7.3.5', '@angular/common': '~8.0.2', '@angular/compiler': '~8.0.2', '@angular/compiler-cli': '~8.0.2', '@angular/core': '~8.0.2', '@angular/forms': '~8.0.2','@angular/platform-browser': '~8.0.2', '@angular/platform-browser-dynamic': '~8.0.2', '@angular/router': '~8.0.2', '@angular-devkit/build-angular': '~0.13.0', '@ng-bootstrap/ng-bootstrap': '^4.2.1', '@types/node': '~8.9.4', 'bootstrap': '^4.3.1', 'core-js': '^2.5.4', 'rxjs': '~6.5.2', 'tslib': '^1.9.0', 'typescript': '~3.4.5', 'zone.js': '~0.9.1', 'fs-extra': '8.1.0'}",
         "key": "dependencies",
         "jsonPath": "package.json"
       },
@@ -84,7 +84,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'start-frontend': 'ng serve --port=3000 --o --proxy-config proxy.config.json', 'ng': 'ng', 'build': 'ng build && mv build server', 'test': 'ng test', 'lint': 'ng lint', 'e2e': 'ng e2e'}",
+        "dict": "{'start-frontend': 'ng serve --port=3000 --o --proxy-config proxy.config.json', 'ng': 'ng', 'build': 'node ./buildScript', 'test': 'ng test', 'lint': 'ng lint', 'e2e': 'ng e2e'}",
         "key": "scripts",
         "jsonPath": "package.json"
       },

--- a/templates/Web/Projects/AngularDefault/buildScript.js
+++ b/templates/Web/Projects/AngularDefault/buildScript.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const fse = require("fs-extra");
+const childProcess = require("child_process");
+
+if (fs.existsSync("./build")) {
+  fse.removeSync("./build");
+}
+
+childProcess.execSync("ng build", { stdio: "inherit" });
+
+fse.moveSync("./build", "./server/build", { overwrite: true });

--- a/templates/Web/Projects/ReactDefault/.template.config/template.json
+++ b/templates/Web/Projects/ReactDefault/.template.config/template.json
@@ -62,7 +62,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'bootstrap': '^4.3.1', 'classnames': '^2.2.6', 'react': '^16.8.4', 'react-dom': '^16.8.4', 'react-router-dom': '^4.3.1', 'react-scripts': '^3.0.1'}",
+        "dict": "{'bootstrap': '^4.3.1', 'classnames': '^2.2.6', 'react': '^16.8.4', 'react-dom': '^16.8.4', 'react-router-dom': '^4.3.1', 'react-scripts': '^3.0.1', 'fs-extra': '8.1.0'}",
         "key": "dependencies",
         "jsonPath": "package.json"
       },
@@ -73,7 +73,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'start-frontend': 'react-scripts start', 'build': 'react-scripts build && mv build server', 'test': 'react-scripts test', 'eject': 'react-scripts eject'}",
+        "dict": "{'start-frontend': 'react-scripts start', 'build': 'node ./buildScript', 'test': 'react-scripts test', 'eject': 'react-scripts eject'}",
         "key": "scripts",
         "jsonPath": "package.json"
       },

--- a/templates/Web/Projects/ReactDefault/buildScript.js
+++ b/templates/Web/Projects/ReactDefault/buildScript.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const fse = require("fs-extra");
+const childProcess = require("child_process");
+
+if (fs.existsSync("./build")) {
+  fse.removeSync("./build");
+}
+
+childProcess.execSync("react-scripts build", { stdio: "inherit" });
+
+fse.moveSync("./build", "./server/build", { overwrite: true });

--- a/templates/Web/Projects/VueDefault/.template.config/template.json
+++ b/templates/Web/Projects/VueDefault/.template.config/template.json
@@ -62,7 +62,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'bootstrap': '^4.3.1', 'bootstrap-vue': '^2.0.0-rc.27', 'core-js': '^2.6.5', 'vue': '^2.6.6', 'vue-router': '^3.0.4'}",
+        "dict": "{'bootstrap': '^4.3.1', 'bootstrap-vue': '^2.0.0-rc.27', 'core-js': '^2.6.5', 'vue': '^2.6.6', 'vue-router': '^3.0.4', 'fs-extra': '8.1.0'}",
         "key": "dependencies",
         "jsonPath": "package.json"
       },
@@ -84,7 +84,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'start-frontend': 'vue-cli-service serve --open', 'build': 'vue-cli-service build && mv build server', 'lint': 'vue-cli-service lint'}",
+        "dict": "{'start-frontend': 'vue-cli-service serve --open', 'build': 'node ./buildScript', 'lint': 'vue-cli-service lint'}",
         "key": "scripts",
         "jsonPath": "package.json"
       },

--- a/templates/Web/Projects/VueDefault/buildScript.js
+++ b/templates/Web/Projects/VueDefault/buildScript.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const fse = require("fs-extra");
+const childProcess = require("child_process");
+
+if (fs.existsSync("./build")) {
+  fse.removeSync("./build");
+}
+
+childProcess.execSync("vue-cli-service build", { stdio: "inherit" });
+
+fse.moveSync("./build", "./server/build", { overwrite: true });


### PR DESCRIPTION
Task: https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/32678

**Changes**
- Add a script for the command `npm run build`
- The script is added to make the `mv` command cross-platform
- Also, it checks for corner cases such as overwriting the build folder in case it is already present in the server folder.
