### PR TITLE
customize vs code default color for high contrast

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -64,6 +64,17 @@
         "category": "%webTemplateStudioExtension.commands.wts%"
       }
     ],
+    "colors": [
+      {
+        "id": "editorWidget.border",
+        "description": "Color for error message in the status bar.",
+        "defaults": {
+          "dark": "#454545",
+          "light": "#c8c8c8",
+          "highContrast": "#800000"
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "%webTemplateStudioExtension.commands.wts%",


### PR DESCRIPTION
As the designer @xtinah-w 's requirement, the default colour for input fields is failing for accessibility. Thus this PR overwrites the default input/button colour for high contrast theme. The new colour should effect the entire wizard

**How to test:**
1. start the extension
2. `ctrl + k` then `ctrl + t` to switch colour themes to High Contrast
3. go through the entire wizard, you should see this colour, and no more light blue. 

**Expected** ( @xtinah-w please confirm if this is the color you want):
<img width="634" alt="Screen Shot 2019-08-14 at 8 49 51 PM" src="https://user-images.githubusercontent.com/12874317/63071834-bd045500-bed5-11e9-9576-bf7c570d3eaa.png">
<img width="723" alt="Screen Shot 2019-08-14 at 8 55 38 PM" src="https://user-images.githubusercontent.com/12874317/63071876-e3c28b80-bed5-11e9-82c3-7010426fc6eb.png">


Before:
<img width="468" alt="Screen Shot 2019-08-14 at 8 51 31 PM" src="https://user-images.githubusercontent.com/12874317/63071838-bf66af00-bed5-11e9-9a40-d7d694b6a244.png">