### PR TITLE
Responsive preview on page details

### DIFF
--- a/src/client/src/containers/PageDetails/styles.module.css
+++ b/src/client/src/containers/PageDetails/styles.module.css
@@ -15,3 +15,15 @@
   margin-top: 51px;
   /*Height of the Title Bar */
 }
+
+@media (max-width: 850px) {
+  .detailsContainer {
+    display: block;
+  }
+
+  .screenShotContainer {
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}


### PR DESCRIPTION
GitHub Issue #1109 

**Changes**
- Make the preview image on page details page responsive so that it comes under the details if screen size is less than 850px

**More than 850px**
![image](https://user-images.githubusercontent.com/35667299/63305327-3ff12b00-c29b-11e9-864e-3fb7ec93406f.png)

**Less than 850px**
![image](https://user-images.githubusercontent.com/35667299/63305380-7333ba00-c29b-11e9-8b96-9d9fc53114a5.png)

closes #1109 