### PR TITLE
Flask Template - Port to 5000 for Flask Standard

### DIFF
--- a/templates/Web/Projects/FlaskDefault/server/constants.py
+++ b/templates/Web/Projects/FlaskDefault/server/constants.py
@@ -1,7 +1,7 @@
 import os
 
 CONSTANTS = {
-    'PORT': os.environ.get('PORT', 3001),
+    'PORT': os.environ.get('PORT', 5000),
     'HTTP_STATUS': {
         '404_NOT_FOUND': 404,
     },


### PR DESCRIPTION
Flask works out-of-the-box on port 5000 but not on other ports (such as the 3001 used), so starting a project will lead to issues and components not working (as I experienced with Vue). This is alleviated by leaving the Flask port to 5000 and allowing the user to configure further as desired. Ultimately, we don't want end-users to have a bundled project that doesn't work on the first start, so I'm making this PR.