### PR TITLE
Limit react-scripts to 3.2.0 until fix the library

### DIFF
--- a/templates/Web/Projects/ReactDefault/.template.config/template.json
+++ b/templates/Web/Projects/ReactDefault/.template.config/template.json
@@ -64,7 +64,7 @@
       "manualInstructions": [],
       "actionId": "CB387AC0-16D0-4E07-B41A-F1EA616A7CA9",
       "args": {
-        "dict": "{'bootstrap': '^4.3.1', 'classnames': '^2.2.6', 'react': '^16.8.4', 'react-dom': '^16.8.4', 'react-router-dom': '^4.3.1', 'react-scripts': '^3.0.1', 'fs-extra': '8.1.0'}",
+        "dict": "{'bootstrap': '^4.3.1', 'classnames': '^2.2.6', 'react': '^16.8.4', 'react-dom': '^16.8.4', 'react-router-dom': '^4.3.1', 'react-scripts': '3.2.0', 'fs-extra': '8.1.0'}",
         "key": "dependencies",
         "jsonPath": "package.json"
       },


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
Limit react-scripts to 3.2.0 until fix the library, with this version msedge + react work fine
- Which issue does this PR relate to?
#1282 

