### PR TITLE
Remove MBS and SMM from Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # At least one of the code owners below will be required on each PR:
-* @markAtMicrosoft @sibille @mvegaca @dgomezc @smmatte @trevorNgo @jcoc611-microsoft @piotrmark @MehaKaushik @Tanya0609 @javieraparisivaldes
+* @sibille @mvegaca @dgomezc @trevorNgo @jcoc611-microsoft @piotrmark @MehaKaushik @Tanya0609 @javieraparisivaldes
 


### PR DESCRIPTION
## PR checklist

Simple PR to remove MBS and SMM from Vancouver Garage from CODEOWNERS file.
