### PR TITLE
Fix Cosmos MongoDB services in all backend framework

### DIFF
--- a/templates/Web/_composition/AspNet/Feature.AspNet.Azure.Cosmos.Mongo/backend/Startup_postaction.cs
+++ b/templates/Web/_composition/AspNet/Feature.AspNet.Azure.Cosmos.Mongo/backend/Startup_postaction.cs
@@ -34,6 +34,7 @@ using MongoDB.Driver;
 
             settings.UseTls = true;
             settings.SslSettings = new SslSettings() { EnabledSslProtocols = SslProtocols.Tls12 };
+            settings.RetryWrites = false;
 
             return new MongoClient(settings);
         }

--- a/templates/Web/_composition/Flask/Feature.Flask.Azure.Cosmos.Mongo/backend/mongo/mongo_client.py
+++ b/templates/Web/_composition/Flask/Feature.Flask.Azure.Cosmos.Mongo/backend/mongo/mongo_client.py
@@ -7,7 +7,7 @@ from .settings import connection_str, cosmosDB_user, cosmosDB_password
 
 
 
-client = MongoClient(connection_str + '?ssl=true&replicaSet=globaldb')
+client = MongoClient(connection_str + '?ssl=true&replicaSet=globaldb&retryWrites=false')
 
 db = client[CONSTANTS['COSMOS']['COLLECTION']]
 

--- a/templates/Web/_composition/MoleculerJS/Feature.Moleculer.Azure.Cosmos.Mongo/backend/mixins/db.mixin.js
+++ b/templates/Web/_composition/MoleculerJS/Feature.Moleculer.Azure.Cosmos.Mongo/backend/mixins/db.mixin.js
@@ -19,7 +19,8 @@ module.exports = opt => {
           password: process.env.COSMOSDB_PASSWORD
         },
         useNewUrlParser: true,
-        useUnifiedTopology: true
+        useUnifiedTopology: true,
+        retryWrites: false
       }
     ),
     // Set DB collection name

--- a/templates/Web/_composition/NodeJS/Feature.Node.Azure.Cosmos.Mongo/backend/mongo/mongoConnect.js
+++ b/templates/Web/_composition/NodeJS/Feature.Node.Azure.Cosmos.Mongo/backend/mongo/mongoConnect.js
@@ -11,7 +11,9 @@ function connect() {
         user: process.env.COSMOSDB_USER,
         password: process.env.COSMOSDB_PASSWORD
       },
-      useNewUrlParser: true
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      retryWrites: false
     })
     .then(() => console.log("Connection to CosmosDB successful"))
     .catch(err => console.error(err));


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
  - Add `retryWrites = false` property in mongoDB client constructors.
- Which issue does this PR relate to?
  - #1717 - Failure when writing to Cosmos MongoDB Service